### PR TITLE
Faster build & install

### DIFF
--- a/ndk-build/src/apk.rs
+++ b/ndk-build/src/apk.rs
@@ -85,11 +85,11 @@ impl<'a> UnalignedApk<'a> {
         std::fs::copy(path, out.join(&file_name))?;
 
         let mut aapt = self.0.build_tool(bin!("aapt"))?;
-        aapt.arg("add").arg(self.0.unaligned_apk()).arg(format!(
-            "lib/{}/{}",
-            abi,
-            file_name.to_str().unwrap()
-        ));
+        aapt.arg("add")
+            .arg("-0")
+            .arg("")
+            .arg(self.0.unaligned_apk())
+            .arg(format!("lib/{}/{}", abi, file_name.to_str().unwrap()));
         if !aapt.status()?.success() {
             return Err(NdkError::CmdFailed(aapt));
         }

--- a/ndk-build/src/apk.rs
+++ b/ndk-build/src/apk.rs
@@ -165,7 +165,10 @@ impl Apk {
 
     pub fn install(&self) -> Result<(), NdkError> {
         let mut adb = self.ndk.platform_tool(bin!("adb"))?;
-        adb.arg("install").arg("-r").arg(&self.path);
+        adb.arg("install")
+            .arg("-r")
+            .arg("--fastdeploy")
+            .arg(&self.path);
         if !adb.status()?.success() {
             return Err(NdkError::CmdFailed(adb));
         }


### PR DESCRIPTION
Here are some tweaks that increase the build and install speed a lot for me.
Disabling compression on the apk entries in particular reduced the build time from ~12 seconds to just 2 seconds on my project, which helps a lot with development iteration speed.

This PR is not meant to be merged as it is, but to open a conversation about how this sort of build optimisations could be included in cargo apk, whether as one or multiple command line arguments, or `Cargo.toml` option(s).