### PR TITLE
media_codec: Fix `dequeue_output_buffer` treating some events as error

### DIFF
--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - event: Add `tool_type` getter for `Pointer`. (#323)
 - input_queue: Allow any non-zero return code from `pre_dispatch()` again, as per documentation. (#325)
+- media_codec: Fix `dequeue_input_buffer` and `dequeue_output_buffer` misinterpreting some errors as buffer indices. (#316)
 
 # 0.7.0 (2022-07-24)
 


### PR DESCRIPTION
The MediaCodec wrapper had some issues with handling some non-error results for `dequeue_output_buffer`. This PR fixes it.

The PR has been tested for the decoder path in soon-to-be-in-production code. I did not experience any unhandleable error originating inside the ndk calls.

Here I used `unreachable!()` to avoid adding an unused variant in `MediaCodecOutputResult` and I would like some feedback for a better solution.