### PR TITLE
ndk/asset: Make reference to `AssetManager::open()` an intradoc link

### DIFF
--- a/ndk/src/asset.rs
+++ b/ndk/src/asset.rs
@@ -36,7 +36,7 @@ impl AssetManager {
         self.ptr
     }
 
-    /// Open the asset. Returns `None` if opening the asset fails.
+    /// Open the asset. Returns [`None`] if opening the asset fails.
     ///
     /// This currently always opens the asset in the streaming mode.
     pub fn open(&self, filename: &CStr) -> Option<Asset> {
@@ -50,7 +50,7 @@ impl AssetManager {
         }
     }
 
-    /// Open an asset directory. Returns `None` if opening the directory fails.
+    /// Open an asset directory. Returns [`None`] if opening the directory fails.
     pub fn open_dir(&self, filename: &CStr) -> Option<AssetDir> {
         unsafe {
             let ptr = ffi::AAssetManager_openDir(self.ptr.as_ptr(), filename.as_ptr());
@@ -116,10 +116,10 @@ impl AssetDir {
         self.ptr
     }
 
-    /// Get the next filename, if any, and process it.  Like `.next()`, but performs no additional
-    /// allocation.
+    /// Get the next filename, if any, and process it.  Like [`Iterator::next()`], but performs
+    /// no additional allocation.
     ///
-    /// The filenames are in the correct format to be passed to `AssetManager::open`
+    /// The filenames are in the correct format to be passed to [`AssetManager::open()`].
     pub fn with_next<T>(&mut self, f: impl for<'a> FnOnce(&'a CStr) -> T) -> Option<T> {
         unsafe {
             let next_name = ffi::AAssetDir_getNextFileName(self.ptr.as_ptr());


### PR DESCRIPTION
While browsing these docs I could not click through to this function while it should obviously be very easy to jump to it.

Also reference the `.next()` function more appropriately.
