### PR TITLE
ndk/asset: Use entire asset length when mapping buffer

### DIFF
--- a/ndk/src/asset.rs
+++ b/ndk/src/asset.rs
@@ -206,7 +206,7 @@ impl Asset {
         unsafe { ffi::AAsset_getRemainingLength64(self.ptr.as_ptr()) as usize }
     }
 
-    /// Reads all data into a buffer and returns it
+    /// Maps all data into a buffer and returns it
     pub fn get_buffer(&mut self) -> io::Result<&[u8]> {
         unsafe {
             let buf_ptr = ffi::AAsset_getBuffer(self.ptr.as_ptr());
@@ -218,7 +218,7 @@ impl Asset {
             } else {
                 Ok(std::slice::from_raw_parts(
                     buf_ptr as *const u8,
-                    self.get_remaining_length(),
+                    self.get_length(),
                 ))
             }
         }


### PR DESCRIPTION
According to `AAsset_getBuffer` documentation:

    Get a pointer to a buffer holding the entire contents of the assset.

This means the returned pointer points to the _start of_ the asset, and will thus be pointing to a memory range as long as the asset.  If the user had first read X bytes before mapping it as a buffer, there will now be X bytes cut off at the end of the buffer since `get_remaining_length()` returns `get_length() - X` at this point.
