### PR TITLE
ndk: Drop optional `jni-glue` dependency

### DIFF
--- a/ndk/Cargo.toml
+++ b/ndk/Cargo.toml
@@ -28,7 +28,7 @@ api-level-28 = ["api-level-27"]
 api-level-29 = ["api-level-28"]
 api-level-30 = ["api-level-29"]
 
-test = ["ffi/test", "jni", "jni-glue", "all"]
+test = ["ffi/test", "jni", "all"]
 
 [dependencies]
 bitflags = "1.2.1"
@@ -41,17 +41,13 @@ thiserror = "1.0.23"
 version = "0.19"
 optional = true
 
-[dependencies.jni-glue]
-version = "0.0.10"
-optional = true
-
 [dependencies.ffi]
 package = "ndk-sys"
 path = "../ndk-sys"
 version = "0.4.0"
 
 [package.metadata.docs.rs]
-features = ["jni", "jni-glue", "all"]
+features = ["jni", "all"]
 rustdoc-args = ["--cfg", "docsrs"]
 targets = [
     "aarch64-linux-android",

--- a/ndk/src/native_activity.rs
+++ b/ndk/src/native_activity.rs
@@ -142,17 +142,6 @@ impl NativeActivity {
     /// let env = vm.attach_current_thread();
     /// // Do JNI with env ...
     /// ```
-    ///
-    /// Usage with [__jni-glue__](https://crates.io/crates/jni-glue) crate:
-    /// ```no_run
-    /// # use ndk::native_activity::NativeActivity;
-    /// # let native_activity: NativeActivity = unimplemented!();
-    /// let vm_ptr = native_activity.vm();
-    /// let vm = unsafe { jni_glue::VM::from_jni_local(&*vm_ptr) };
-    /// vm.with_env(|env| {
-    ///     // Do JNI with env ...
-    /// });
-    /// ```
     pub fn vm(&self) -> *mut jni_sys::JavaVM {
         unsafe { self.ptr.as_ref() }.vm
     }


### PR DESCRIPTION
This crate doesn't seem to have taken off (3 years since last update) against the `jni` and `jni-sys` crate, and the `ndk` only uses it for a single (compile-testable) documentation example.
