### PR TITLE
Bump `bitflags` to `2.0.0`

### DIFF
--- a/ndk/Cargo.toml
+++ b/ndk/Cargo.toml
@@ -31,7 +31,7 @@ api-level-30 = ["api-level-29"]
 test = ["ffi/test", "jni", "all"]
 
 [dependencies]
-bitflags = "1.2.1"
+bitflags = "2.0.0"
 jni-sys = "0.3.0"
 num_enum = "0.5.1"
 raw-window-handle = "0.5"

--- a/ndk/src/looper.rs
+++ b/ndk/src/looper.rs
@@ -31,6 +31,7 @@ pub struct ThreadLooper {
 
 bitflags! {
     /// Flags for file descriptor events that a looper can monitor.
+    #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
     pub struct FdEvent: u32 {
         const INPUT = ffi::ALOOPER_EVENT_INPUT;
         const OUTPUT = ffi::ALOOPER_EVENT_OUTPUT;

--- a/ndk/src/native_activity.rs
+++ b/ndk/src/native_activity.rs
@@ -17,6 +17,7 @@ bitflags! {
     /// <https://developer.android.com/ndk/reference/group/native-activity#group___native_activity_1ga2f1398dba5e4a5616b83437528bdb28e>
     ///
     /// [`android.view.WindowManager.LayoutParams`]: https://developer.android.com/reference/android/view/WindowManager.LayoutParams
+    #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
     pub struct WindowFlags: u32 {
         const ALLOW_LOCK_WHILE_SCREEN_ON = ffi::AWINDOW_FLAG_ALLOW_LOCK_WHILE_SCREEN_ON;
         const DIM_BEHIND = ffi::AWINDOW_FLAG_DIM_BEHIND;


### PR DESCRIPTION
Changelog: https://github.com/bitflags/bitflags/blob/2.0.0/CHANGELOG.md#200.

This is a breaking change. The API that is implemented by the macro is now different.