### PR TITLE
ndk: Upgrade `num_enum` crate from `0.5.1` to `0.6`

### DIFF
--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -5,6 +5,7 @@
 - asset: Use entire asset length when mapping buffer. (#387)
 - Bump MSRV to 1.64 for `raw-window-handle 0.5.1`. (#388)
 - Bump optional `jni` dependency for doctest example from `0.19` to `0.21`. (#390)
+- **Breaking:** Upgrade `num_enum` crate from `0.5.1` to `0.6`. (#398)
 
 # 0.7.0 (2022-07-24)
 

--- a/ndk/Cargo.toml
+++ b/ndk/Cargo.toml
@@ -33,7 +33,7 @@ test = ["ffi/test", "jni", "all"]
 [dependencies]
 bitflags = "1.2.1"
 jni-sys = "0.3.0"
-num_enum = "0.5.1"
+num_enum = "0.6"
 raw-window-handle = "0.5"
 thiserror = "1.0.23"
 


### PR DESCRIPTION
Fixes #392, cc @kchibisov 