### PR TITLE
ndk/media_codec: Inline `get_unlikely_to_be_null()`

### DIFF
--- a/ndk/src/media/media_codec.rs
+++ b/ndk/src/media/media_codec.rs
@@ -3,7 +3,7 @@
 //! [`AMediaFormat`]: https://developer.android.com/ndk/reference/group/media#amediaformat
 //! [`AMediaCodec`]: https://developer.android.com/ndk/reference/group/media#amediacodec
 
-use super::{get_unlikely_to_be_null, NdkMediaError, Result};
+use super::{NdkMediaError, Result};
 use crate::native_window::NativeWindow;
 use std::{
     convert::TryInto,
@@ -350,14 +350,14 @@ impl MediaCodec {
 
     #[cfg(feature = "api-level-28")]
     pub fn input_format(&self) -> MediaFormat {
-        let inner =
-            get_unlikely_to_be_null(|| unsafe { ffi::AMediaCodec_getInputFormat(self.as_ptr()) });
+        let inner = NonNull::new(unsafe { ffi::AMediaCodec_getInputFormat(self.as_ptr()) })
+            .expect("AMediaCodec_getInputFormat returned NULL");
         MediaFormat { inner }
     }
 
     pub fn output_format(&self) -> MediaFormat {
-        let inner =
-            get_unlikely_to_be_null(|| unsafe { ffi::AMediaCodec_getOutputFormat(self.as_ptr()) });
+        let inner = NonNull::new(unsafe { ffi::AMediaCodec_getOutputFormat(self.as_ptr()) })
+            .expect("AMediaCodec_getOutputFormat returned NULL");
         MediaFormat { inner }
     }
 
@@ -495,9 +495,10 @@ impl OutputBuffer<'_> {
 
     #[cfg(feature = "api-level-28")]
     pub fn format(&self) -> MediaFormat {
-        let inner = get_unlikely_to_be_null(|| unsafe {
+        let inner = NonNull::new(unsafe {
             ffi::AMediaCodec_getBufferFormat(self.codec.as_ptr(), self.index)
-        });
+        })
+        .expect("AMediaCodec_getBufferFormat returned NULL");
         MediaFormat { inner }
     }
 

--- a/ndk/src/media/mod.rs
+++ b/ndk/src/media/mod.rs
@@ -29,13 +29,3 @@ fn construct_never_null<T>(
     };
     Ok(non_null)
 }
-
-/// Function is not expected to ever return `null`, but this
-/// cannot be validated through the Android documentation.
-///
-/// As such this function always asserts on `null` values,
-/// even when `cfg!(debug_assertions)` is disabled.
-fn get_unlikely_to_be_null<T>(get_ptr: impl FnOnce() -> *mut T) -> NonNull<T> {
-    let result = get_ptr();
-    NonNull::new(result).expect("result should never be null")
-}


### PR DESCRIPTION
Back when I refactored these in #248 and #256 the closure argument should have been removed entirely as it is only called immediately without any arguments, so its return value could have been passed instead.  At that point the function becomes simple enough to warrant removal entirely, inlining the unwrap and even allowing a more natural string literal error message in `.expect()`.

CC @zarik5
