### PR TITLE
ndk/media_codec: Wrap common dequeued-buffer status codes in enum

### DIFF
--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -9,6 +9,7 @@
 - **Breaking:** Upgrade `bitflags` crate from `1` to `2`. (#394)
 - **Breaking:** Upgrade `num_enum` crate from `0.5.1` to `0.6`. (#398)
 - **Breaking:** Renamed and moved "`media`" error types and helpers to a new `media_error` module. (#399)
+- **Breaking:** media_codec: Wrap common dequeued-buffer status codes in enum. (#401)
 
 # 0.7.0 (2022-07-24)
 


### PR DESCRIPTION
Supersedes #316, CC @zarik5
Closes #316

The dequeue API for output buffers can commonly return `AMEDIACODEC_INFO_OUTPUT_FORMAT_CHANGED` or `AMEDIACODEC_INFO_OUTPUT_BUFFERS_CHANGED`, both of which are not caught in `NdkMediaError::from_status()` and show up as an "unknown" error.  Neither really is an error that the user would want to bubble up from the `Result<>` via `?`, but should rather handle this explicitly.

A similar case already exists for `AMEDIACODEC_INFO_TRY_AGAIN_LATER` which previously resulted in a `None`, but is now also encapsuled in a self-documenting manner, for the dequeue_input_buffer()` API as well.
