### PR TITLE
ndk/media_codec: Return `MaybeUninit` bytes in `buffer_mut()`

### DIFF
--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -10,6 +10,7 @@
 - **Breaking:** Upgrade `num_enum` crate from `0.5.1` to `0.6`. (#398)
 - **Breaking:** Renamed and moved "`media`" error types and helpers to a new `media_error` module. (#399)
 - **Breaking:** media_codec: Wrap common dequeued-buffer status codes in enum. (#401)
+- **Breaking:** media_codec: Return `MaybeUninit` bytes in `buffer_mut()`. (#403)
 
 # 0.7.0 (2022-07-24)
 

--- a/ndk/src/media/media_codec.rs
+++ b/ndk/src/media/media_codec.rs
@@ -466,7 +466,7 @@ pub struct InputBuffer<'a> {
 }
 
 impl InputBuffer<'_> {
-    pub fn buffer_mut(&mut self) -> &mut [u8] {
+    pub fn buffer_mut(&mut self) -> &mut [MaybeUninit<u8>] {
         unsafe {
             let mut out_size = 0;
             let buffer_ptr =
@@ -476,7 +476,7 @@ impl InputBuffer<'_> {
                 "AMediaCodec_getInputBuffer returned NULL for index {}",
                 self.index
             );
-            slice::from_raw_parts_mut(buffer_ptr, out_size)
+            slice::from_raw_parts_mut(buffer_ptr.cast(), out_size)
         }
     }
 }


### PR DESCRIPTION
Depends on #401, CC @zarik5

The byte-array mapped/returned by `AMediaCodec_getInputBuffer()` is not known to be initialized as the caller requires this API to subsequently initialize the data, and mapping/casting uninitialized memory segments as safe data in Rust is Undefined Behaviour.  Instead, return a `MaybeUninit<u8>` type to be safe (as in: the user cannot *safely* read data in the returned slice, only write to it) and document the intent back to the user.

Unfortunately, as of writing many useful API around _slices of_ `MaybeUninit` are still unstable.

