### PR TITLE
hardware_buffer_format: Add `YCbCr_P010` and `R8_UNORM` variants

### DIFF
--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -11,6 +11,7 @@
 - **Breaking:** Renamed and moved "`media`" error types and helpers to a new `media_error` module. (#399)
 - **Breaking:** media_codec: Wrap common dequeued-buffer status codes in enum. (#401)
 - **Breaking:** media_codec: Return `MaybeUninit` bytes in `buffer_mut()`. (#403)
+- hardware_buffer_format: Add `YCbCr_P010` and `R8_UNORM` variants. (#405)
 
 # 0.7.0 (2022-07-24)
 

--- a/ndk/src/hardware_buffer_format.rs
+++ b/ndk/src/hardware_buffer_format.rs
@@ -35,4 +35,8 @@ pub enum HardwareBufferFormat {
     S8_UINT = ffi::AHardwareBuffer_Format::AHARDWAREBUFFER_FORMAT_S8_UINT.0,
     #[cfg(feature = "api-level-26")]
     Y8Cb8Cr8_420 = ffi::AHardwareBuffer_Format::AHARDWAREBUFFER_FORMAT_Y8Cb8Cr8_420.0,
+    #[cfg(feature = "api-level-26")]
+    YCbCr_P010 = ffi::AHardwareBuffer_Format::AHARDWAREBUFFER_FORMAT_YCbCr_P010.0,
+    #[cfg(feature = "api-level-26")]
+    R8_UNORM = ffi::AHardwareBuffer_Format::AHARDWAREBUFFER_FORMAT_R8_UNORM.0,
 }


### PR DESCRIPTION
These seem to have been added in the NDK r25 release.
