### PR TITLE
ndk/asset: Add missing `is_allocated()` and `open_file_descriptor()`

### DIFF
--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -17,6 +17,7 @@
 - native_window: Add `lock()` to blit raw pixel data. (#404)
 - hardware_buffer_format: Add `YCbCr_P010` and `R8_UNORM` variants. (#405)
 - **Breaking:** hardware_buffer_format: Add catch-all variant. (#407)
+- ndk/asset: Add missing `is_allocated()` and `open_file_descriptor()` methods. (#409)
 - **Breaking:** media_codec: Add support for asynchronous notification callbacks. (#410)
 - Add panic guards to callbacks. (#412)
 - looper: Add `remove_fd()` to unregister events/callbacks for a file descriptor. (#416)


### PR DESCRIPTION
These two functions are not exactly critical but may be useful to some developers.

`is_allocated()` tells us whether a backing buffer is created in RAM, or if the data is directly `mmap()`'ed from the APK (e.g. because no decompression was needed and alignment requirements are upheld).  Note that it only returns `true` after the asset is "mapped" (or read in some way) via e.g `get_buffer()`; solely opening the asset is not enough to trigger the allocation and decompression.

`open_file_descriptor()` gives the user a file descriptor, which simply seems to be a `dup()` of that from the opened APK, together with an offset and size of the given `AAsset` within that APK.  It also requires the asset to be stored uncompressed within the APK.
