### PR TITLE
media_error: Add `MediaStatus::from_status_if_negative()` helper

### DIFF
--- a/ndk/src/media/media_codec.rs
+++ b/ndk/src/media/media_codec.rs
@@ -525,13 +525,12 @@ impl MediaCodec {
 
         if result == ffi::AMEDIACODEC_INFO_TRY_AGAIN_LATER as isize {
             Ok(DequeuedInputBufferResult::TryAgainLater)
-        } else if result >= 0 {
+        } else {
+            let index = MediaError::from_status_if_negative(result)? as usize;
             Ok(DequeuedInputBufferResult::Buffer(InputBuffer {
                 codec: self,
-                index: result as usize,
+                index,
             }))
-        } else {
-            Err(MediaError::from_status(ffi::media_status_t(result as _)).unwrap_err())
         }
     }
 
@@ -558,16 +557,15 @@ impl MediaCodec {
             Ok(DequeuedOutputBufferInfoResult::OutputFormatChanged)
         } else if result == ffi::AMEDIACODEC_INFO_OUTPUT_BUFFERS_CHANGED as isize {
             Ok(DequeuedOutputBufferInfoResult::OutputBuffersChanged)
-        } else if result >= 0 {
+        } else {
+            let index = MediaError::from_status_if_negative(result)? as usize;
             Ok(DequeuedOutputBufferInfoResult::Buffer(OutputBuffer {
                 codec: self,
-                index: result as usize,
+                index,
                 info: BufferInfo {
                     inner: unsafe { info.assume_init() },
                 },
             }))
-        } else {
-            Err(MediaError::from_status(ffi::media_status_t(result as _)).unwrap_err())
         }
     }
 

--- a/ndk/src/media_error.rs
+++ b/ndk/src/media_error.rs
@@ -1,13 +1,12 @@
 //! Bindings for NDK media status codes.
 //!
-//! Also used outside of `libmediandk.so` in `libmidi.so` for example.
-
+//! Also used outside of `libmediandk.so` in `libamidi.so` for example.
 #![cfg(feature = "media")]
 // The cfg(feature) bounds for some pub(crate) fn uses are non-trivial and will become even more
 // complex going forward.  Allow them to be unused when compiling with certain feature combinations.
 #![allow(dead_code)]
 
-use std::{mem::MaybeUninit, ptr::NonNull};
+use std::{convert::TryInto, mem::MaybeUninit, ptr::NonNull};
 
 use thiserror::Error;
 
@@ -56,7 +55,10 @@ pub enum MediaError {
 }
 
 impl MediaError {
-    /// Returns [`Ok`] on [`ffi::media_status_t::AMEDIA_OK`], [`Err`] otherwise.
+    /// Returns [`Ok`] on [`ffi::media_status_t::AMEDIA_OK`], [`Err`] otherwise (including positive
+    /// values).
+    ///
+    /// Note that some known error codes (currently only for `AMediaCodec`) are positive.
     pub(crate) fn from_status(status: ffi::media_status_t) -> Result<()> {
         use MediaStatus::*;
         Err(Self::MediaStatus(match status {
@@ -92,6 +94,25 @@ impl MediaError {
             ffi::media_status_t::AMEDIA_IMGREADER_IMAGE_NOT_LOCKED => ImgreaderImageNotLocked,
             _ => return Err(MediaError::UnknownStatus(status)),
         }))
+    }
+
+    /// Returns the original value in [`Ok`] if it is not negative, [`Err`] otherwise.
+    ///
+    /// Note that some [`ffi::media_status_t`] codes are positive but will never be returned as
+    /// [`Err`] from this function. As of writing these codes are specific to the `AMediaCodec` API
+    /// and should not be handled generically.
+    pub(crate) fn from_status_if_negative<T: Into<isize> + Copy>(value: T) -> Result<T> {
+        let v = value.into();
+        if v >= 0 {
+            Ok(value)
+        } else {
+            Err(Self::from_status(ffi::media_status_t(
+                v.try_into().expect("Error code out of bounds"),
+            ))
+            // This panic should be unreachable: the only case where Ok is returned is in
+            // AMEDIA_OK=0 whose value is already handled above.
+            .unwrap_err())
+        }
     }
 }
 


### PR DESCRIPTION
CC @paxbun

Covers a prevalent `unwrap_err()` pattern for negative status codes, where we want to use any non-negative status code as a useful value and otherwise assert that `from_status()` turns the raw value into an appropriate error code (never into `Ok(())`, which should be unreachable in the current implementation).

Note that we cannot rely on `from_status()` returning `Ok(())` or `Err(_)` and translate the `Ok(())` back to the original value, as it handles (as of writing) two positive error codes which only relate to a specific `AMediaCodec` API, and any unrecognized codes including >0 are treated as `UnknownStatus`.

The function consumes `Into<isize>` instead of `i32/c_int` or `ffi::media_status_t` to support passing through numbers from various APIs that return 64-bit numbers (e.g. `MediaCodec`).  The value only needs to be truncated (with a panic on `try_into()`) when it is lower than zero and needs to be converted to `ffi::media_status_t`.
