### PR TITLE
Bump to edition 2021 and clean up 2018 idioms

### DIFF
--- a/ndk-sys/Cargo.toml
+++ b/ndk-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ndk-sys"
 version = "0.4.1+23.1.7779620"  # Current source contains 25.2.9519653
 authors = ["The Rust Windowing contributors"]
-edition = "2018"
+edition = "2021"
 description = "FFI bindings for the Android NDK"
 license = "MIT OR Apache-2.0"
 keywords = ["android", "ndk"]

--- a/ndk/Cargo.toml
+++ b/ndk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ndk"
 version = "0.7.0"
 authors = ["The Rust Windowing contributors"]
-edition = "2018"
+edition = "2021"
 description = "Safe Rust bindings to the Android NDK"
 license = "MIT OR Apache-2.0"
 keywords = ["android", "ndk"]

--- a/ndk/src/audio.rs
+++ b/ndk/src/audio.rs
@@ -12,7 +12,6 @@ use crate::utils::abort_on_panic;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use std::{
     borrow::Cow,
-    convert::TryFrom,
     ffi::{c_void, CStr},
     fmt,
     mem::MaybeUninit,
@@ -398,7 +397,7 @@ pub struct AudioStreamBuilder {
 }
 
 impl fmt::Debug for AudioStreamBuilder {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("AAudioStreamBuilder")
             .field("inner", &self.inner)
             .field(
@@ -916,7 +915,7 @@ pub struct AudioStream {
 }
 
 impl fmt::Debug for AudioStream {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("AAudioStream")
             .field("inner", &self.inner)
             .field(

--- a/ndk/src/bitmap.rs
+++ b/ndk/src/bitmap.rs
@@ -8,7 +8,7 @@
 
 use jni_sys::{jobject, JNIEnv};
 use num_enum::{IntoPrimitive, TryFromPrimitive, TryFromPrimitiveError};
-use std::{convert::TryInto, mem::MaybeUninit};
+use std::mem::MaybeUninit;
 
 #[cfg(feature = "api-level-30")]
 use crate::hardware_buffer::HardwareBufferRef;

--- a/ndk/src/bitmap.rs
+++ b/ndk/src/bitmap.rs
@@ -22,7 +22,7 @@ pub enum BitmapError {
     JniException = ffi::ANDROID_BITMAP_RESULT_JNI_EXCEPTION,
 }
 
-pub type BitmapResult<T, E = BitmapError> = std::result::Result<T, E>;
+pub type BitmapResult<T, E = BitmapError> = Result<T, E>;
 
 impl BitmapError {
     pub(crate) fn from_status(status: i32) -> BitmapResult<()> {

--- a/ndk/src/configuration.rs
+++ b/ndk/src/configuration.rs
@@ -11,7 +11,6 @@
 
 use crate::asset::AssetManager;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
-use std::convert::TryInto;
 use std::fmt;
 use std::ptr::NonNull;
 
@@ -49,7 +48,7 @@ impl PartialEq for Configuration {
 impl Eq for Configuration {}
 
 impl fmt::Debug for Configuration {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Configuration")
             .field("mcc", &self.mcc())
             .field("mnc", &self.mnc())

--- a/ndk/src/event.rs
+++ b/ndk/src/event.rs
@@ -11,7 +11,6 @@
 //! [`android.view.KeyEvent`]: https://developer.android.com/reference/android/view/KeyEvent
 
 use num_enum::{IntoPrimitive, TryFromPrimitive};
-use std::convert::TryInto;
 use std::ptr::NonNull;
 
 /// A native [`AInputEvent *`]

--- a/ndk/src/lib.rs
+++ b/ndk/src/lib.rs
@@ -3,7 +3,12 @@
 //! Bindings to the [Android NDK].
 //!
 //! [Android NDK]: https://developer.android.com/ndk/reference
-#![warn(missing_debug_implementations, trivial_casts, rust_2018_idioms)]
+#![warn(
+    missing_debug_implementations,
+    rust_2018_idioms,
+    trivial_casts,
+    unused_qualifications
+)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 pub mod asset;

--- a/ndk/src/lib.rs
+++ b/ndk/src/lib.rs
@@ -3,7 +3,7 @@
 //! Bindings to the [Android NDK].
 //!
 //! [Android NDK]: https://developer.android.com/ndk/reference
-#![warn(missing_debug_implementations, trivial_casts)]
+#![warn(missing_debug_implementations, trivial_casts, rust_2018_idioms)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 pub mod asset;

--- a/ndk/src/looper.rs
+++ b/ndk/src/looper.rs
@@ -10,7 +10,6 @@
 //! [`ALooper`]: https://developer.android.com/ndk/reference/group/looper#alooper
 
 use bitflags::bitflags;
-use std::convert::TryInto;
 use std::mem::ManuallyDrop;
 use std::os::raw::c_void;
 use std::os::unix::io::RawFd;

--- a/ndk/src/media/image_reader.rs
+++ b/ndk/src/media/image_reader.rs
@@ -9,7 +9,6 @@ use crate::native_window::NativeWindow;
 use crate::utils::abort_on_panic;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use std::{
-    convert::TryInto,
     ffi::c_void,
     fmt::{self, Debug, Formatter},
     mem::MaybeUninit,
@@ -61,7 +60,7 @@ pub struct ImageReader {
 }
 
 impl Debug for ImageReader {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("ImageReader")
             .field("inner", &self.inner)
             .field(

--- a/ndk/src/media/media_codec.rs
+++ b/ndk/src/media/media_codec.rs
@@ -6,7 +6,6 @@
 use crate::media_error::{MediaError, Result};
 use crate::native_window::NativeWindow;
 use std::{
-    convert::TryInto,
     ffi::{CStr, CString},
     fmt::Display,
     mem::MaybeUninit,
@@ -381,7 +380,7 @@ impl MediaCodec {
 
     pub fn queue_input_buffer(
         &self,
-        buffer: InputBuffer,
+        buffer: InputBuffer<'_>,
         offset: usize,
         size: usize,
         time: u64,
@@ -400,7 +399,7 @@ impl MediaCodec {
         MediaError::from_status(status)
     }
 
-    pub fn release_output_buffer(&self, buffer: OutputBuffer, render: bool) -> Result<()> {
+    pub fn release_output_buffer(&self, buffer: OutputBuffer<'_>, render: bool) -> Result<()> {
         let status =
             unsafe { ffi::AMediaCodec_releaseOutputBuffer(self.as_ptr(), buffer.index, render) };
         MediaError::from_status(status)
@@ -408,7 +407,7 @@ impl MediaCodec {
 
     pub fn release_output_buffer_at_time(
         &self,
-        buffer: OutputBuffer,
+        buffer: OutputBuffer<'_>,
         timestamp_ns: i64,
     ) -> Result<()> {
         let status = unsafe {

--- a/ndk/src/native_activity.rs
+++ b/ndk/src/native_activity.rs
@@ -216,8 +216,12 @@ impl NativeActivity {
     ///
     /// [`getWindow().setFormat()`]: https://developer.android.com/reference/android/view/Window#setFormat(int)
     pub fn set_window_format(&self, format: HardwareBufferFormat) {
-        let format: ffi::AHardwareBuffer_Format = format.into();
-        unsafe { ffi::ANativeActivity_setWindowFormat(self.ptr.as_ptr(), format.0 as i32) }
+        unsafe {
+            ffi::ANativeActivity_setWindowFormat(
+                self.ptr.as_ptr(),
+                ffi::AHardwareBuffer_Format::from(format).0 as i32,
+            )
+        }
     }
 
     /// Change the window flags of the given activity.

--- a/ndk/src/native_window.rs
+++ b/ndk/src/native_window.rs
@@ -7,7 +7,7 @@ use crate::utils::status_to_io_result;
 pub use super::hardware_buffer_format::HardwareBufferFormat;
 use jni_sys::{jobject, JNIEnv};
 use raw_window_handle::{AndroidNdkWindowHandle, HasRawWindowHandle, RawWindowHandle};
-use std::{convert::TryFrom, ffi::c_void, io::Result, mem::MaybeUninit, ptr::NonNull};
+use std::{ffi::c_void, io::Result, mem::MaybeUninit, ptr::NonNull};
 
 pub type Rect = ffi::ARect;
 
@@ -133,7 +133,7 @@ impl NativeWindow {
     ///
     /// Optionally pass the region you intend to draw into `dirty_bounds`.  When this function
     /// returns it is updated (commonly enlarged) with the actual area the caller needs to redraw.
-    pub fn lock(&self, dirty_bounds: Option<&mut Rect>) -> Result<NativeWindowBufferLockGuard> {
+    pub fn lock(&self, dirty_bounds: Option<&mut Rect>) -> Result<NativeWindowBufferLockGuard<'_>> {
         let dirty_bounds = match dirty_bounds {
             Some(dirty_bounds) => dirty_bounds,
             None => std::ptr::null_mut(),

--- a/ndk/src/native_window.rs
+++ b/ndk/src/native_window.rs
@@ -191,7 +191,7 @@ impl<'a> NativeWindowBufferLockGuard<'a> {
     /// line of pixels in the buffer.
     ///
     /// See [`bytes()`][Self::bytes()] for safe access to these bytes.
-    pub fn bits(&mut self) -> *mut std::ffi::c_void {
+    pub fn bits(&mut self) -> *mut c_void {
         self.buffer.bits
     }
 

--- a/ndk/src/surface_texture.rs
+++ b/ndk/src/surface_texture.rs
@@ -8,7 +8,7 @@
 
 use crate::{native_window::NativeWindow, utils::status_to_io_result};
 use jni_sys::{jobject, JNIEnv};
-use std::{convert::TryInto, io::Result, ptr::NonNull, time::Duration};
+use std::{io::Result, ptr::NonNull, time::Duration};
 
 /// An opaque type to manage [`android.graphics.SurfaceTexture`] from native code
 ///

--- a/ndk/src/trace.rs
+++ b/ndk/src/trace.rs
@@ -24,7 +24,7 @@ impl Section {
     }
 
     pub fn end(self) {
-        std::mem::drop(self)
+        drop(self)
     }
 }
 
@@ -62,7 +62,7 @@ impl AsyncSection {
     }
 
     pub fn end(self) {
-        std::mem::drop(self)
+        drop(self)
     }
 }
 


### PR DESCRIPTION
We've never cleaned up our code to utilize some Rust 2018 idioms.  And by bumping to 2021 we get a more elaborate prelude allowing us to drop `TryFrom`/`TryInto` imports.
