### PR TITLE
ndk/looper: Add `remove_fd()` method

### DIFF
--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -16,6 +16,7 @@
 - hardware_buffer_format: Add `YCbCr_P010` and `R8_UNORM` variants. (#405)
 - **Breaking:** hardware_buffer_format: Add catch-all variant. (#407)
 - Add panic guards to callbacks. (#412)
+- looper: Add `remove_fd()` to unregister events/callbacks for a file descriptor. (#416)
 
 # 0.7.0 (2022-07-24)
 


### PR DESCRIPTION
We've previously only been able to unregister file descriptors by using a callback and returning `false` from it to be unregistered.  Add the missing method that allows users to unregister their file descriptors from the looper for any reason.

There has always been a "concern" about leaking the `Box` inside `add_fd_with_callback()`, but this is already very easy by never returning `false` from the callback or registering a different callback / event on the same `fd`, so this new function doesn't really expose that.
