### PR TITLE
ndk: Use `BorrowedFd` and `OwnedFd` to clarify ownership transitions

### DIFF
--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -20,6 +20,7 @@
 - **Breaking:** media_codec: Add support for asynchronous notification callbacks. (#410)
 - Add panic guards to callbacks. (#412)
 - looper: Add `remove_fd()` to unregister events/callbacks for a file descriptor. (#416)
+- **Breaking:** Use `BorrowedFd` and `OwnedFd` to clarify possible ownership transitions. (#417)
 - **Breaking:** Upgrade to [`ndk-sys 0.5.0`](../ndk-sys/CHANGELOG.md#050-beta0-2023-08-15). (#420)
 
 # 0.7.0 (2022-07-24)

--- a/ndk/src/hardware_buffer.rs
+++ b/ndk/src/hardware_buffer.rs
@@ -9,7 +9,15 @@ use crate::utils::status_to_io_result;
 pub use super::hardware_buffer_format::HardwareBufferFormat;
 use jni_sys::{jobject, JNIEnv};
 use std::{
-    io::Result, mem::MaybeUninit, ops::Deref, os::raw::c_void, os::unix::io::RawFd, ptr::NonNull,
+    io::Result,
+    mem::MaybeUninit,
+    ops::Deref,
+    os::{
+        raw::c_void,
+        // TODO: Import from std::os::fd::{} since Rust 1.66
+        unix::io::{AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd},
+    },
+    ptr::NonNull,
 };
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -263,10 +271,10 @@ impl HardwareBuffer {
     pub fn lock(
         &self,
         usage: HardwareBufferUsage,
-        fence: Option<RawFd>,
+        fence: Option<OwnedFd>,
         rect: Option<Rect>,
     ) -> Result<*mut c_void> {
-        let fence = fence.unwrap_or(-1);
+        let fence = fence.map_or(-1, IntoRawFd::into_raw_fd);
         let rect = match rect {
             Some(rect) => &rect,
             None => std::ptr::null(),
@@ -287,10 +295,10 @@ impl HardwareBuffer {
     pub fn lock_and_get_info(
         &self,
         usage: HardwareBufferUsage,
-        fence: Option<RawFd>,
+        fence: Option<OwnedFd>,
         rect: Option<Rect>,
     ) -> Result<LockedPlaneInfo> {
-        let fence = fence.unwrap_or(-1);
+        let fence = fence.map_or(-1, IntoRawFd::into_raw_fd);
         let rect = match rect {
             Some(rect) => &rect,
             None => std::ptr::null(),
@@ -339,10 +347,10 @@ impl HardwareBuffer {
     pub fn lock_planes(
         &self,
         usage: HardwareBufferUsage,
-        fence: Option<RawFd>,
+        fence: Option<OwnedFd>,
         rect: Option<Rect>,
     ) -> Result<HardwareBufferPlanes> {
-        let fence = fence.unwrap_or(-1);
+        let fence = fence.map_or(-1, IntoRawFd::into_raw_fd);
         let rect = match rect {
             Some(rect) => &rect,
             None => std::ptr::null(),
@@ -373,21 +381,24 @@ impl HardwareBuffer {
     /// [`None`] if unlocking is already finished. The caller is responsible for closing the file
     /// descriptor once it's no longer needed. See [`unlock()`][Self::unlock()] for a variant that
     /// blocks instead.
-    pub fn unlock_async(&self) -> Result<Option<RawFd>> {
+    pub fn unlock_async(&self) -> Result<Option<OwnedFd>> {
         let fence = construct(|res| unsafe { ffi::AHardwareBuffer_unlock(self.as_ptr(), res) })?;
         Ok(match fence {
             -1 => None,
-            fence => Some(fence),
+            fence => Some(unsafe { OwnedFd::from_raw_fd(fence) }),
         })
     }
 
     /// Receive a [`HardwareBuffer`] from an `AF_UNIX` socket.
     ///
-    /// `AF_UNIX` sockets are wrapped by [`std::os::unix::net::UnixListener`] in Rust.
-    pub fn recv_handle_from_unix_socket(socket_fd: RawFd) -> Result<Self> {
+    /// `AF_UNIX` sockets are wrapped by [`std::os::unix::net::UnixListener`] and
+    /// [`std::os::unix::net::UnixStream`] in Rust and have a corresponding
+    /// [`std::os::unix::io::AsFd::as_fd()`] implementation.
+    pub fn recv_handle_from_unix_socket(socket_fd: BorrowedFd<'_>) -> Result<Self> {
         unsafe {
-            let ptr =
-                construct(|res| ffi::AHardwareBuffer_recvHandleFromUnixSocket(socket_fd, res))?;
+            let ptr = construct(|res| {
+                ffi::AHardwareBuffer_recvHandleFromUnixSocket(socket_fd.as_raw_fd(), res)
+            })?;
 
             Ok(Self::from_ptr(NonNull::new_unchecked(ptr)))
         }
@@ -395,10 +406,13 @@ impl HardwareBuffer {
 
     /// Send the [`HardwareBuffer`] to an `AF_UNIX` socket.
     ///
-    /// `AF_UNIX` sockets are wrapped by [`std::os::unix::net::UnixListener`] in Rust.
-    pub fn send_handle_to_unix_socket(&self, socket_fd: RawFd) -> Result<()> {
-        let status =
-            unsafe { ffi::AHardwareBuffer_sendHandleToUnixSocket(self.as_ptr(), socket_fd) };
+    /// `AF_UNIX` sockets are wrapped by [`std::os::unix::net::UnixListener`] and
+    /// [`std::os::unix::net::UnixStream`] in Rust and have a corresponding
+    /// [`std::os::unix::io::AsFd::as_fd()`] implementation.
+    pub fn send_handle_to_unix_socket(&self, socket_fd: BorrowedFd<'_>) -> Result<()> {
+        let status = unsafe {
+            ffi::AHardwareBuffer_sendHandleToUnixSocket(self.as_ptr(), socket_fd.as_raw_fd())
+        };
         status_to_io_result(status, ())
     }
 


### PR DESCRIPTION
Depends on #416

Some functions consume a file descriptor (will close them on their own regard) or return ownership over a file descriptor (expect the caller to close it), but this is not always clarified in the documentation nor upheld by the caller.  Use the new stabilized `BorrowedFd` and `OwnedFd` types since Rust 1.63 to clarify this in the API, noting that `OwnedFd` will instinctively `close()` the file descriptor on drop and doesn't implement `Copy` nor `Clone` (but does provide a `try_clone()` helper using `fcntl()` to create a new owned file descriptor if needed, and if possible by the kernel).

For example, while not obvious from `AHardwareBuffer_lock()` docs (though there are hints in the [graphics sync docs]) the source for gralloc buffer locking many function calls down clarifies that the [`acquireFence` is indeed owned and will be closed].  The same [applies to `AImageReader` and its async aquire functions].

[graphics sync docs]: https://source.android.com/docs/core/graphics/sync
[`acquireFence` is indeed owned and will be closed]: https://cs.android.com/android/platform/superproject/main/+/refs/heads/main:frameworks/native/libs/ui/Gralloc4.cpp;l=320-323;drc=34edaadf5297f2c066d2cb09a5cc9366dc35b24b
[applies to `AImageReader` and its async aquire functions]: https://cs.android.com/android/platform/superproject/main/+/refs/heads/main:frameworks/av/media/ndk/NdkImageReader.cpp;l=498-501;drc=34edaadf5297f2c066d2cb09a5cc9366dc35b24b
