### PR TITLE
ndk/hardware_buffer: Add API-31 `getId()` function to `HardwareBuffer`

### DIFF
--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -24,6 +24,7 @@
 - looper: Add `remove_fd()` to unregister events/callbacks for a file descriptor. (#416)
 - **Breaking:** Use `BorrowedFd` and `OwnedFd` to clarify possible ownership transitions. (#417)
 - **Breaking:** Upgrade to [`ndk-sys 0.5.0`](../ndk-sys/CHANGELOG.md#050-beta0-2023-08-15). (#420)
+- hardware_buffer: Add `id()` to retrieve a system-wide unique identifier for a `HardwareBuffer`. (#428)
 
 # 0.7.0 (2022-07-24)
 

--- a/ndk/Cargo.toml
+++ b/ndk/Cargo.toml
@@ -27,6 +27,7 @@ api-level-27 = ["api-level-26"]
 api-level-28 = ["api-level-27"]
 api-level-29 = ["api-level-28"]
 api-level-30 = ["api-level-29"]
+api-level-31 = ["api-level-30"]
 
 test = ["ffi/test", "jni", "all"]
 

--- a/ndk/src/hardware_buffer.rs
+++ b/ndk/src/hardware_buffer.rs
@@ -233,6 +233,13 @@ impl HardwareBuffer {
         res == 1
     }
 
+    /// Get the system-wide unique id for this [`HardwareBuffer`].
+    #[cfg(feature = "api-level-31")]
+    #[doc(alias = "AHardwareBuffer_getId")]
+    pub fn id(&self) -> Result<u64> {
+        construct(|res| unsafe { ffi::AHardwareBuffer_getId(self.as_ptr(), res) })
+    }
+
     /// Lock the [`HardwareBuffer`] for direct CPU access.
     ///
     /// This function can lock the buffer for either reading or writing. It may block if the


### PR DESCRIPTION
This is the only new/missing function in our `HardwareBuffer` wrapper, except the `AParcel` functions that cannot be bound until that type is mapped.
