### PR TITLE
ndk/media_error: Flatten `MediaStatus` and `MediaError` with `catch_all`

### DIFF
--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -12,7 +12,7 @@
 - bitmap: Add `try_format()` to `AndroidBitmapInfo` to handle unexpected formats without panicking. (#395)
 - Add `Font` bindings. (#397)
 - **Breaking:** Upgrade `num_enum` crate from `0.5.1` to `0.7`. (#398, #419)
-- **Breaking:** Renamed and moved "`media`" error types and helpers to a new `media_error` module. (#399)
+- **Breaking:** Renamed, moved and flattened "`media`" error types and helpers to a new `media_error` module. (#399, #432)
 - **Breaking:** media_codec: Wrap common dequeued-buffer status codes in enum. (#401)
 - **Breaking:** media_codec: Return `MaybeUninit` bytes in `buffer_mut()`. (#403)
 - native_window: Add `lock()` to blit raw pixel data. (#404)

--- a/ndk/src/media/image_reader.rs
+++ b/ndk/src/media/image_reader.rs
@@ -4,7 +4,7 @@
 //! [`AImage`]: https://developer.android.com/ndk/reference/group/media#aimage
 #![cfg(feature = "api-level-24")]
 
-use crate::media_error::{construct, construct_never_null, MediaError, MediaStatus, Result};
+use crate::media_error::{construct, construct_never_null, MediaError, Result};
 use crate::native_window::NativeWindow;
 use crate::utils::abort_on_panic;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
@@ -208,7 +208,7 @@ impl ImageReader {
 
         match res {
             Ok(inner) => Ok(Some(Image { inner })),
-            Err(MediaError::MediaStatus(MediaStatus::ImgreaderNoBufferAvailable)) => Ok(None),
+            Err(MediaError::ImgreaderNoBufferAvailable) => Ok(None),
             Err(e) => Err(e),
         }
     }
@@ -240,7 +240,7 @@ impl ImageReader {
             ffi::AImageReader_acquireLatestImage(self.as_ptr(), res)
         });
 
-        if let Err(MediaError::MediaStatus(MediaStatus::ImgreaderNoBufferAvailable)) = res {
+        if let Err(MediaError::ImgreaderNoBufferAvailable) = res {
             return Ok(None);
         }
 


### PR DESCRIPTION
~Depends on #431~

Since bumping our MSRV to 1.66 `num_enum` provides a `catch_all` variant which we can use to store yet-unknown or yet-unmapped error codes, rather than having them in a secondary `enum` which derives `thiserror`.

This also allows us to get rid of a manual `match` statement, which can be (but could already have been...) generated by `num_enum` via `TryFromPrimitive` before.
