### PR TITLE
ndk/native_window: Implement `HasWindowHandle` for 0.4 and 0.6 (and maintain 0.5)

### DIFF
--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -28,6 +28,7 @@
 - native_window: Add `set_buffers_transform()`, `try_allocate_buffers()` and `set_frame_rate*()`. (#425)
 - hardware_buffer: Add `id()` to retrieve a system-wide unique identifier for a `HardwareBuffer`. (#428)
 - **Breaking:** bitmap: Strip `Android` prefix from structs and enums, and `Bitmap` from `Result`. (#430)
+- **Breaking:** `raw-window-handle 0.5` support is now behind an _optional_ `rwh_05` crate feature and `raw-window-handle` `0.4` and `0.6` support is provided via the new `rwh_04` and (default-enabled) `rwh_06` crate features. (#434)
 
 # 0.7.0 (2022-07-24)
 

--- a/ndk/Cargo.toml
+++ b/ndk/Cargo.toml
@@ -13,7 +13,8 @@ repository = "https://github.com/rust-mobile/ndk"
 rust-version = "1.66"
 
 [features]
-all = ["audio", "bitmap","media", "api-level-31"]
+default = ["rwh_06"]
+all = ["audio", "bitmap","media", "api-level-31", "rwh_04", "rwh_05", "rwh_06"]
 
 audio = ["ffi/audio", "api-level-26"]
 bitmap = ["ffi/bitmap"]
@@ -36,7 +37,9 @@ bitflags = "2.0.0"
 jni-sys = "0.3.0"
 log = "0.4"
 num_enum = "0.7"
-raw-window-handle = "0.5"
+rwh_04 = { package = "raw-window-handle", version = "0.4", optional = true }
+rwh_05 = { package = "raw-window-handle", version = "0.5", optional = true }
+rwh_06 = { package = "raw-window-handle", version = "0.6", optional = true }
 thiserror = "1.0.23"
 
 [dependencies.jni]


### PR DESCRIPTION
Following [the same strategy in winit], move `raw-window-handle 0.5` behind a `rwh_05` feature and add `raw-window-handle 0.4` and the newly released `raw-window-handle 0.6` behind a corresponding `rwh04`/`rwh_06` feature.  The new **non-raw** trait and **lifetimed** type since `0.6` have been implemented instead, as `raw-window-handle` provides blanket implementations to coerce/convert back to `Raw*` types.


[the same strategy in winit]: https://github.com/rust-windowing/winit/pull/3126
