### PR TITLE
looper: Provide `event` value to file descriptor poll callback

### DIFF
--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -29,6 +29,7 @@
 - hardware_buffer: Add `id()` to retrieve a system-wide unique identifier for a `HardwareBuffer`. (#428)
 - **Breaking:** bitmap: Strip `Android` prefix from structs and enums, and `Bitmap` from `Result`. (#430)
 - **Breaking:** `raw-window-handle 0.5` support is now behind an _optional_ `rwh_05` crate feature and `raw-window-handle` `0.4` and `0.6` support is provided via the new `rwh_04` and (default-enabled) `rwh_06` crate features. (#434)
+- **Breaking:** looper: Provide `event` value to file descriptor poll callback. (#435)
 
 # 0.7.0 (2022-07-24)
 


### PR DESCRIPTION
When `looper` calls a callback that triggered for a poll on a file descriptor it provides the reason for the wakeup, because users are allowed to register multiple.  Hence it is important for the user to know the trigger reason to enact on the result appropriately.  E.g. a `HANGUP` typically requires the callback to be deregistered by returning `false`, as the other end (for a `pipe()` or `socket()`) has been closed and this file descriptor should no longer trigger any other event.

Note that various events are received by this callback regardless of whether the user registered it with that flag in `events`. This is all reflected by updating the documentation comments for `FdEvent` based on upstream Android documentation.

Keep in mind that `FdEvent` is a `bitflag`, and Android uses that to batch up multiple events.  E.g. writing to a `pipe()` and closing the write `fd` - while the read `fd` is registered in a callback - causes the callback (from a subsequent `looper.poll*()`) to be called with `INPUT | HANGUP`, indicating that there is data to read but that the file descriptor will be dormant after that.
