### PR TITLE
Remove public reexports of `HardwareBufferFormat`

### DIFF
--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -30,6 +30,7 @@
 - **Breaking:** bitmap: Strip `Android` prefix from structs and enums, and `Bitmap` from `Result`. (#430)
 - **Breaking:** `raw-window-handle 0.5` support is now behind an _optional_ `rwh_05` crate feature and `raw-window-handle` `0.4` and `0.6` support is provided via the new `rwh_04` and (default-enabled) `rwh_06` crate features. (#434)
 - **Breaking:** looper: Provide `event` value to file descriptor poll callback. (#435)
+- **Breaking:** `HardwareBufferFormat` is no longer exported from `hardware_buffer` and `native_window`, and can only be reached through the `hardware_buffer_format` module. (#436)
 
 # 0.7.0 (2022-07-24)
 

--- a/ndk/src/hardware_buffer.rs
+++ b/ndk/src/hardware_buffer.rs
@@ -4,10 +4,6 @@
 
 #![cfg(feature = "api-level-26")]
 
-use crate::utils::status_to_io_result;
-
-pub use super::hardware_buffer_format::HardwareBufferFormat;
-use jni_sys::{jobject, JNIEnv};
 use std::{
     io::Result,
     mem::MaybeUninit,
@@ -18,6 +14,10 @@ use std::{
     },
     ptr::NonNull,
 };
+
+use jni_sys::{jobject, JNIEnv};
+
+use super::{hardware_buffer_format::HardwareBufferFormat, utils::status_to_io_result};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct HardwareBufferUsage(pub ffi::AHardwareBuffer_UsageFlags);

--- a/ndk/src/native_window.rs
+++ b/ndk/src/native_window.rs
@@ -2,11 +2,11 @@
 //!
 //! [`ANativeWindow`]: https://developer.android.com/ndk/reference/group/a-native-window#anativewindow
 
-use crate::utils::status_to_io_result;
-
-pub use super::hardware_buffer_format::HardwareBufferFormat;
-use jni_sys::{jobject, JNIEnv};
 use std::{ffi::c_void, io, mem::MaybeUninit, ptr::NonNull};
+
+use jni_sys::{jobject, JNIEnv};
+
+use super::{hardware_buffer_format::HardwareBufferFormat, utils::status_to_io_result};
 
 pub type Rect = ffi::ARect;
 


### PR DESCRIPTION
This was previously reexported from `hardware_buffer` in #276 to maintain backwards compatibility when the type was originally defined inside that module.  However, the type was also strangely reexported from `native_window` (probably a copy-paste error) while it is accessible from the public `hardware_buffer_format` module leading to **three** individual modules where `HardwareBufferFormat` can be imported from.

Reduce this duplication and confusion by forcing it to only be reachable from the canonical `hardware_buffer_format` module.
