### PR TITLE
audio: rename `AudioErrorResult` to `AudioResult` and make `non_exhaustive`

### DIFF
--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Add `DataSpace` type and relevant functions on `Bitmap` and `NativeWindow`. (#438)
 - bitmap: Add `Bitmap::compress()` and `Bitmap::compress_raw()` functions. (#440)
 - **Breaking:** Turn `BitmapError` into a `non_exhaustive` `enum`. (#440)
+- **Breaking:** audio: Rename `AudioErrorResult` to `AudioResult` and turn into a `non_exhaustive` `enum`. (#441)
 
 # 0.7.0 (2022-07-24)
 

--- a/ndk/src/media_error.rs
+++ b/ndk/src/media_error.rs
@@ -15,38 +15,69 @@ pub type Result<T, E = MediaError> = std::result::Result<T, E>;
 /// Media Status codes for [`media_status_t`](https://developer.android.com/ndk/reference/group/media#group___media_1ga009a49041fe39f7bdc6d8b5cddbe760c)
 #[repr(i32)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, FromPrimitive, IntoPrimitive)]
+#[doc(alias = "media_status_t")]
 #[non_exhaustive]
 pub enum MediaError {
+    #[doc(alias = "AMEDIACODEC_ERROR_INSUFFICIENT_RESOURCE")]
     CodecErrorInsufficientResource = ffi::media_status_t::AMEDIACODEC_ERROR_INSUFFICIENT_RESOURCE.0,
+    #[doc(alias = "AMEDIACODEC_ERROR_RECLAIMED")]
     CodecErrorReclaimed = ffi::media_status_t::AMEDIACODEC_ERROR_RECLAIMED.0,
+    #[doc(alias = "AMEDIA_ERROR_UNKNOWN")]
     ErrorUnknown = ffi::media_status_t::AMEDIA_ERROR_UNKNOWN.0,
+    #[doc(alias = "AMEDIA_ERROR_MALFORMED")]
     ErrorMalformed = ffi::media_status_t::AMEDIA_ERROR_MALFORMED.0,
+    #[doc(alias = "AMEDIA_ERROR_UNSUPPORTED")]
     ErrorUnsupported = ffi::media_status_t::AMEDIA_ERROR_UNSUPPORTED.0,
+    #[doc(alias = "AMEDIA_ERROR_INVALID_OBJECT")]
     ErrorInvalidObject = ffi::media_status_t::AMEDIA_ERROR_INVALID_OBJECT.0,
+    #[doc(alias = "AMEDIA_ERROR_INVALID_PARAMETER")]
     ErrorInvalidParameter = ffi::media_status_t::AMEDIA_ERROR_INVALID_PARAMETER.0,
+    #[doc(alias = "AMEDIA_ERROR_INVALID_OPERATION")]
     ErrorInvalidOperation = ffi::media_status_t::AMEDIA_ERROR_INVALID_OPERATION.0,
+    #[doc(alias = "AMEDIA_ERROR_END_OF_STREAM")]
     ErrorEndOfStream = ffi::media_status_t::AMEDIA_ERROR_END_OF_STREAM.0,
+    #[doc(alias = "AMEDIA_ERROR_IO")]
     ErrorIo = ffi::media_status_t::AMEDIA_ERROR_IO.0,
+    #[doc(alias = "AMEDIA_ERROR_WOULD_BLOCK")]
     ErrorWouldBlock = ffi::media_status_t::AMEDIA_ERROR_WOULD_BLOCK.0,
+    #[doc(alias = "AMEDIA_DRM_ERROR_BASE")]
     DrmErrorBase = ffi::media_status_t::AMEDIA_DRM_ERROR_BASE.0,
+    #[doc(alias = "AMEDIA_DRM_NOT_PROVISIONED")]
     DrmNotProvisioned = ffi::media_status_t::AMEDIA_DRM_NOT_PROVISIONED.0,
+    #[doc(alias = "AMEDIA_DRM_RESOURCE_BUSY")]
     DrmResourceBusy = ffi::media_status_t::AMEDIA_DRM_RESOURCE_BUSY.0,
+    #[doc(alias = "AMEDIA_DRM_DEVICE_REVOKED")]
     DrmDeviceRevoked = ffi::media_status_t::AMEDIA_DRM_DEVICE_REVOKED.0,
+    #[doc(alias = "AMEDIA_DRM_SHORT_BUFFER")]
     DrmShortBuffer = ffi::media_status_t::AMEDIA_DRM_SHORT_BUFFER.0,
+    #[doc(alias = "AMEDIA_DRM_SESSION_NOT_OPENED")]
     DrmSessionNotOpened = ffi::media_status_t::AMEDIA_DRM_SESSION_NOT_OPENED.0,
+    #[doc(alias = "AMEDIA_DRM_TAMPER_DETECTED")]
     DrmTamperDetected = ffi::media_status_t::AMEDIA_DRM_TAMPER_DETECTED.0,
+    #[doc(alias = "AMEDIA_DRM_VERIFY_FAILED")]
     DrmVerifyFailed = ffi::media_status_t::AMEDIA_DRM_VERIFY_FAILED.0,
+    #[doc(alias = "AMEDIA_DRM_NEED_KEY")]
     DrmNeedKey = ffi::media_status_t::AMEDIA_DRM_NEED_KEY.0,
+    #[doc(alias = "AMEDIA_DRM_LICENSE_EXPIRED")]
     DrmLicenseExpired = ffi::media_status_t::AMEDIA_DRM_LICENSE_EXPIRED.0,
+    #[doc(alias = "AMEDIA_IMGREADER_ERROR_BASE")]
     ImgreaderErrorBase = ffi::media_status_t::AMEDIA_IMGREADER_ERROR_BASE.0,
+    #[doc(alias = "AMEDIA_IMGREADER_NO_BUFFER_AVAILABLE")]
     ImgreaderNoBufferAvailable = ffi::media_status_t::AMEDIA_IMGREADER_NO_BUFFER_AVAILABLE.0,
+    #[doc(alias = "AMEDIA_IMGREADER_MAX_IMAGES_ACQUIRED")]
     ImgreaderMaxImagesAcquired = ffi::media_status_t::AMEDIA_IMGREADER_MAX_IMAGES_ACQUIRED.0,
+    #[doc(alias = "AMEDIA_IMGREADER_CANNOT_LOCK_IMAGE")]
     ImgreaderCannotLockImage = ffi::media_status_t::AMEDIA_IMGREADER_CANNOT_LOCK_IMAGE.0,
+    #[doc(alias = "AMEDIA_IMGREADER_CANNOT_UNLOCK_IMAGE")]
     ImgreaderCannotUnlockImage = ffi::media_status_t::AMEDIA_IMGREADER_CANNOT_UNLOCK_IMAGE.0,
+    #[doc(alias = "AMEDIA_IMGREADER_IMAGE_NOT_LOCKED")]
     ImgreaderImageNotLocked = ffi::media_status_t::AMEDIA_IMGREADER_IMAGE_NOT_LOCKED.0,
-    // Use the OK discriminant, assuming no-one calls `as i32` and only uses the generated `From` implementation via `IntoPrimitive`
+    /// This error code is unknown to the [`ndk`][crate] crate.  Please report an issue if you
+    /// believe this code needs to be added to our mapping.
+    // Use the OK discriminant, as no-one will be able to call `as i32` and only has access to the
+    // constants via `From` provided by `IntoPrimitive` which reads the contained value.
     #[num_enum(catch_all)]
-    Unknown(i32) = 0,
+    Unknown(i32) = ffi::media_status_t::AMEDIA_OK.0,
 }
 
 impl fmt::Display for MediaError {


### PR DESCRIPTION
Using the new `num_enum` `catch_all` we can now automatically implement the `match` statement and get rid of one superfluous `AudioError` variant.
