### PR TITLE
CI: Only require MSRV-check to succeed with `-Zminimal-versions`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
           - { name: "ndk-sys", target: "armv7-linux-androideabi" }
           - { name: "ndk", target: "armv7-linux-androideabi" }
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           target: ${{ matrix.crate.target }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,17 +38,30 @@ jobs:
         run: cargo check -p ndk-sys --all-targets --all-features --target aarch64-linux-android
 
   check_msrv:
+    strategy:
+      matrix:
+        minimal-versions: [true, false]
     name: Check overall MSRV (1.66.0)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+
+      - uses: dtolnay/rust-toolchain@nightly
+        if: ${{ matrix.minimal-versions }}
+
+      - name: Generate lockfile with minimal dependency versions
+        run: cargo +nightly generate-lockfile -Zminimal-versions
+        if: ${{ matrix.minimal-versions }}
 
       - uses: dtolnay/rust-toolchain@1.66.0
         with:
           target: aarch64-linux-android
 
       - name: cargo check
-        run: cargo check --workspace --all-targets --all-features --target aarch64-linux-android
+        run: >
+          cargo check --workspace --all-targets --all-features --target aarch64-linux-android
+          || (echo "::warning::MSRV test failed for minimal-versions: ${{ matrix.minimal-versions }}"; false)
+        continue-on-error: ${{ !matrix.minimal-versions }}
 
   build:
     strategy:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,7 +6,7 @@ jobs:
   formatting:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Format
         run: cargo fmt --all -- --check
@@ -14,7 +14,7 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -28,7 +28,7 @@ jobs:
     name: Check ndk-sys MSRV (1.60.0)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
 
       - uses: dtolnay/rust-toolchain@1.60.0
         with:
@@ -44,7 +44,7 @@ jobs:
     name: Check overall MSRV (1.66.0)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
 
       - uses: dtolnay/rust-toolchain@nightly
         if: ${{ matrix.minimal-versions }}
@@ -86,7 +86,7 @@ jobs:
     name: Cross-compile
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2
@@ -114,7 +114,7 @@ jobs:
     name: Host-side tests
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Installing Rust ${{ matrix.rust-channel }}
         uses: dtolnay/rust-toolchain@master
@@ -138,7 +138,7 @@ jobs:
     name: Build-test docs
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Installing Rust ${{ matrix.rust-channel }}
         uses: dtolnay/rust-toolchain@master

--- a/ndk/Cargo.toml
+++ b/ndk/Cargo.toml
@@ -34,9 +34,9 @@ api-level-31 = ["api-level-30"]
 test = ["ffi/test", "jni", "all"]
 
 [dependencies]
-bitflags = "2.0.0"
-jni-sys = "0.3.0"
-log = "0.4"
+bitflags = "2.2"
+jni-sys = "0.3"
+log = "0.4.6"
 num_enum = "0.7"
 rwh_04 = { package = "raw-window-handle", version = "0.4", optional = true }
 rwh_05 = { package = "raw-window-handle", version = "0.5", optional = true }
@@ -54,7 +54,7 @@ version = "0.5.0"
 
 [dev-dependencies]
 # Only for use in documentation and doc-tests
-libc = "0.2"
+libc = "0.2.3"
 
 [package.metadata.docs.rs]
 features = ["jni", "all"]


### PR DESCRIPTION
One of our dependencies recently bumped its `rust-version` causing our MSRV test to _break again_.  It is undesired to randomly work around this by bumping our MSRV, or consistently have PRs/merges fail for unrelated reasons.

Instead, perform the MSRV-test with `-Zminimal-versions`.  This seems to be generally accepted in the Rust ecosystem (as there is otherwise no way for crates to bump MSRV barring a semver-breaking release) and prevents us from hitting unnecessary MSRV build failures caused by dependencies.

At the same time our minimal version bounds are now exercised, ensuring downstream crates depending on the `ndk` can build with `-Zminimal-versions` too - which required specifying a few patch bounds for our dependencies.

Unfortunately GitHub's UI for `continue-on-error: true` doesn't make it obvious that a step/job really didn't succeed, this is only visible from the annotations.  Still, it is relevant to keep track of whether our non-`minimal-versions` build adheres to MSRV.