### PR TITLE
cargo: Add missing `sync` feature to `all`

### DIFF
--- a/ndk/Cargo.toml
+++ b/ndk/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.66"
 
 [features]
 default = ["rwh_06"]
-all = ["audio", "bitmap","media", "api-level-31", "rwh_04", "rwh_05", "rwh_06"]
+all = ["audio", "bitmap", "media", "sync", "api-level-31", "rwh_04", "rwh_05", "rwh_06"]
 
 audio = ["ffi/audio", "api-level-26"]
 bitmap = ["ffi/bitmap"]


### PR DESCRIPTION
The docs for this module are missing because its contents weren't picked up in the docs.rs build.
