### PR TITLE
README: Move modularization comment down and use new blockquote syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,3 @@
-> **Note**
-> This repository was recently [modularized](https://github.com/rust-mobile/ndk/issues/372) and the following crates were split into separate repositories:
->
-> Crate | New Location | Notes
-> ------|--------------|------
-> ndk-context | https://github.com/rust-mobile/ndk-context |
-> ndk-glue | https://github.com/rust-mobile/ndk-glue | _deprecated_ - see [android-activity](https://github.com/rust-mobile/android-activity)
-> ndk-macro | https://github.com/rust-mobile/ndk-glue | _deprecated_ - see [android-activity](https://github.com/rust-mobile/android-activity)
-> ndk-build | https://github.com/rust-mobile/cargo-apk |
-> cargo-apk | https://github.com/rust-mobile/cargo-apk |
-
 [![ci](https://github.com/rust-mobile/ndk/actions/workflows/rust.yml/badge.svg)](https://github.com/rust-mobile/ndk/actions/workflows/rust.yml) ![MIT license](https://img.shields.io/badge/License-MIT-green.svg) ![APACHE2 license](https://img.shields.io/badge/License-APACHE2-green.svg)
 
 Rust bindings to the [Android NDK](https://developer.android.com/ndk)
@@ -19,3 +8,14 @@ Name | Description | Badges
 [`ndk`](./ndk) | Safe abstraction of the bindings | [![crates.io](https://img.shields.io/crates/v/ndk.svg)](https://crates.io/crates/ndk) [![Docs](https://docs.rs/ndk/badge.svg)](https://docs.rs/ndk) [![MSRV](https://img.shields.io/badge/rustc-1.64.0+-ab6000.svg)](https://blog.rust-lang.org/2022/09/22/Rust-1.64.0.html)
 
 See these [`ndk-examples`](https://github.com/rust-mobile/cargo-apk/tree/main/examples/examples) and these [`rust-android-examples`](https://github.com/rust-mobile/rust-android-examples) for examples using the NDK.
+
+> [!IMPORTANT]
+> This repository was recently [modularized](https://github.com/rust-mobile/ndk/issues/372) and the following crates were split into separate repositories:
+>
+> Crate | New Location | Notes
+> ------|--------------|------
+> ndk-context | https://github.com/rust-mobile/ndk-context |
+> ndk-glue | https://github.com/rust-mobile/ndk-glue | ⛔ _deprecated_ - see [android-activity](https://github.com/rust-mobile/android-activity)
+> ndk-macro | https://github.com/rust-mobile/ndk-glue | ⛔ _deprecated_ - see [android-activity](https://github.com/rust-mobile/android-activity)
+> ndk-build | https://github.com/rust-mobile/cargo-apk | ⛔ _deprecated_ - see [xbuild](https://github.com/rust-mobile/xbuild)
+> cargo-apk | https://github.com/rust-mobile/cargo-apk | ⛔ _deprecated_ - see [xbuild](https://github.com/rust-mobile/xbuild)


### PR DESCRIPTION
The previous `> **Note**` syntax has been deprecated in favour of `> [!NOTE]` sytnax on November 14th (2 days ago), and newer block types were added: https://github.com/orgs/community/discussions/16925

I'm not quite sure if `IMPORTANT` carries the right load since `Crucial information necessary for users to succeed` is no longer really applicable; most users know where to find the crates and their names haven't changed on crates.io.

Finally, also mention `xbuild` being favoured over `cargo-apk` (even though there's _still_, after all these years some feature disparity).
