### PR TITLE
ndk/media_format: Implement `Debug` in terms of `Display`

### DIFF
--- a/ndk/src/media/media_format.rs
+++ b/ndk/src/media/media_format.rs
@@ -14,7 +14,6 @@ use crate::media_error::{MediaError, Result};
 /// A native [`AMediaFormat *`]
 ///
 /// [`AMediaFormat *`]: https://developer.android.com/ndk/reference/group/media#amediaformat
-#[derive(Debug)]
 #[doc(alias = "AMediaFormat")]
 pub struct MediaFormat {
     inner: NonNull<ffi::AMediaFormat>,
@@ -26,6 +25,13 @@ impl fmt::Display for MediaFormat {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let c_str = unsafe { CStr::from_ptr(ffi::AMediaFormat_toString(self.as_ptr())) };
         f.write_str(c_str.to_str().unwrap())
+    }
+}
+
+impl fmt::Debug for MediaFormat {
+    #[doc(alias = "AMediaFormat_toString")]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "MediaFormat({:?}: {})", self.inner, self)
     }
 }
 


### PR DESCRIPTION
CC @zarik5 @spencercw

Currently `Debug` only prints a raw pointer which is rather useless to look at.  In addition to the pointer, also print the `Display` representation of `MediaFormat` which uses Android's `toString()` function to create a human-readable string of the various fields set inside of it.

On a side-note it is "great" to see that `toString()` is not currently available as a user function via a lifetimed `CStr` as it is invalidated in a nontrivial way (e.g. when `toString()` is called again, and possibly also when `set_()` functions are called which are not currently borrowing it mutably).
