### PR TITLE
ndk: Requre all off-thread `dyn Fn*` callback types to implement `Send`

### DIFF
--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -3,6 +3,16 @@
 - Move `MediaFormat` from `media::media_codec` to its own `media::media_format` module. (#442)
 - media_format: Expose `MediaFormat::copy()` and `MediaFormat::clear()` from API level 29. (#449)
 - **Breaking:** media_format: Mark all `fn set_*()` and `fn str()` as taking `self` by `&mut`. (#452)
+- **Breaking:** Require all `dyn Fn*` types to implement `Send` when the FFI implementation invokes them on a separate thread: (#455)
+  - `audio::AudioStreamDataCallback`;
+  - `audio::AudioStreamErrorCallback`;
+  - `media::image_reader::BufferRemovedListener`;
+  - `media::image_reader::ImageListener`;
+  - `media::media_codec::ErrorCallback`;
+  - `media::media_codec::FormatChangedCallback`;
+  - `media::media_codec::InputAvailableCallback`;
+  - `media::media_codec::OutputAvailableCallback`.
+- Drop previous `Box`ed callbacks _after_ registering new ones, instead of before. (#455)
 - input_queue: Add `from_java()` constructor, available since API level 33. (#456)
 - event: Add `from_java()` constructors to `KeyEvent` and `MotionEvent`, available since API level 31. (#456)
 - event: Implement `SourceClass` `bitflag` and provide `Source::class()` getter. (#458)

--- a/ndk/src/audio.rs
+++ b/ndk/src/audio.rs
@@ -500,9 +500,9 @@ impl fmt::Debug for AudioStreamBuilder {
 
 #[doc(alias = "AAudioStream_dataCallback")]
 pub type AudioStreamDataCallback =
-    Box<dyn FnMut(&AudioStream, *mut c_void, i32) -> AudioCallbackResult>;
+    Box<dyn FnMut(&AudioStream, *mut c_void, i32) -> AudioCallbackResult + Send>;
 #[doc(alias = "AAudioStream_errorCallback")]
-pub type AudioStreamErrorCallback = Box<dyn FnMut(&AudioStream, AudioError)>;
+pub type AudioStreamErrorCallback = Box<dyn FnMut(&AudioStream, AudioError) + Send>;
 
 impl AudioStreamBuilder {
     fn from_ptr(inner: NonNull<ffi::AAudioStreamBuilder>) -> Self {
@@ -643,7 +643,6 @@ impl AudioStreamBuilder {
     pub fn data_callback(mut self, callback: AudioStreamDataCallback) -> Self {
         let mut boxed = Box::new(callback);
         let ptr: *mut AudioStreamDataCallback = &mut *boxed;
-        self.data_callback = Some(boxed);
 
         unsafe extern "C" fn ffi_callback(
             stream: *mut ffi::AAudioStreamStruct,
@@ -671,6 +670,8 @@ impl AudioStreamBuilder {
                 ptr as *mut c_void,
             )
         };
+
+        self.data_callback = Some(boxed);
 
         self
     }
@@ -727,7 +728,6 @@ impl AudioStreamBuilder {
     pub fn error_callback(mut self, callback: AudioStreamErrorCallback) -> Self {
         let mut boxed = Box::new(callback);
         let ptr: *mut AudioStreamErrorCallback = &mut *boxed;
-        self.error_callback = Some(boxed);
 
         unsafe extern "C" fn ffi_callback(
             stream: *mut ffi::AAudioStreamStruct,
@@ -754,6 +754,8 @@ impl AudioStreamBuilder {
                 ptr as *mut c_void,
             )
         };
+
+        self.error_callback = Some(boxed);
 
         self
     }

--- a/ndk/src/media/media_codec.rs
+++ b/ndk/src/media/media_codec.rs
@@ -94,10 +94,10 @@ impl fmt::Debug for AsyncNotifyCallback {
     }
 }
 
-pub type InputAvailableCallback = Box<dyn FnMut(usize)>;
-pub type OutputAvailableCallback = Box<dyn FnMut(usize, &BufferInfo)>;
-pub type FormatChangedCallback = Box<dyn FnMut(&MediaFormat)>;
-pub type ErrorCallback = Box<dyn FnMut(MediaError, ActionCode, &CStr)>;
+pub type InputAvailableCallback = Box<dyn FnMut(usize) + Send>;
+pub type OutputAvailableCallback = Box<dyn FnMut(usize, &BufferInfo) + Send>;
+pub type FormatChangedCallback = Box<dyn FnMut(&MediaFormat) + Send>;
+pub type ErrorCallback = Box<dyn FnMut(MediaError, ActionCode, &CStr) + Send>;
 
 impl MediaCodec {
     fn as_ptr(&self) -> *mut ffi::AMediaCodec {


### PR DESCRIPTION
Fixes #454

In all these cases the NDK either documents or implements the callback to be invoked from a single, separate thread.  For this to be allowed by Rust thread safety, the closures and their (moved) contents are effectively  "moved" to a different thread (`Send`) but not accessed concurrently (`Sync`), but the type definitions were never requiring this marker trait which could lead to undefined/invalid behaviour.

In addition some `Box`ed callbacks may have been dropped before a new callback is passed to the NDK, leading to a possible race condition. By storing the new callback _after_ registering it with the NDK, the previous callback is now dropped later to ensure such race conditions no longer happen (assuming AOSP callback invocations are properly synchronized with the setters).

A request has been filed to solidify this "behavioural contract" in the documentation where not done so yet: https://issuetracker.google.com/issues/300602767#comment12
