### PR TITLE
Add `from_java()` constructors to `InputQueue`, `KeyEvent` and `MotionEvent`

### DIFF
--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Move `MediaFormat` from `media::media_codec` to its own `media::media_format` module. (#442)
 - media_format: Expose `MediaFormat::copy()` and `MediaFormat::clear()` from API level 29. (#449)
 - input_queue: Add `from_java()` constructor, available since API level 33. (#456)
+- event: Add `from_java()` constructors to `KeyEvent` and `MotionEvent`, available since API level 31. (#456)
 
 # 0.8.0 (2023-10-15)
 

--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Move `MediaFormat` from `media::media_codec` to its own `media::media_format` module. (#442)
 - media_format: Expose `MediaFormat::copy()` and `MediaFormat::clear()` from API level 29. (#449)
+- input_queue: Add `from_java()` constructor, available since API level 33. (#456)
 
 # 0.8.0 (2023-10-15)
 

--- a/ndk/Cargo.toml
+++ b/ndk/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.66"
 
 [features]
 default = ["rwh_06"]
-all = ["audio", "bitmap", "media", "sync", "api-level-31", "rwh_04", "rwh_05", "rwh_06"]
+all = ["audio", "bitmap", "media", "sync", "api-level-33", "rwh_04", "rwh_05", "rwh_06"]
 
 audio = ["ffi/audio", "api-level-26"]
 bitmap = ["ffi/bitmap"]
@@ -30,6 +30,8 @@ api-level-28 = ["api-level-27"]
 api-level-29 = ["api-level-28"]
 api-level-30 = ["api-level-29"]
 api-level-31 = ["api-level-30"]
+api-level-32 = ["api-level-31"]
+api-level-33 = ["api-level-32"]
 
 test = ["ffi/test", "jni", "all"]
 

--- a/ndk/src/event.rs
+++ b/ndk/src/event.rs
@@ -6,12 +6,15 @@
 //! [`android.view.KeyEvent`].
 //!
 //! [`AInputEvent`, `AKeyEvent` and `AMotionEvent`]: https://developer.android.com/ndk/reference/group/input
-//! [`android.view.InputEvent`]: https://developer.android.com/reference/android/view/InputEvent.html
-//! [`android.view.MotionEvent`]: https://developer.android.com/reference/android/view/MotionEvent.html
+//! [`android.view.InputEvent`]: https://developer.android.com/reference/android/view/InputEvent
+//! [`android.view.MotionEvent`]: https://developer.android.com/reference/android/view/MotionEvent
 //! [`android.view.KeyEvent`]: https://developer.android.com/reference/android/view/KeyEvent
 
-use num_enum::{IntoPrimitive, TryFromPrimitive};
 use std::ptr::NonNull;
+
+#[cfg(feature = "api-level-31")]
+use jni_sys::{jobject, JNIEnv};
+use num_enum::{IntoPrimitive, TryFromPrimitive};
 
 /// A native [`AInputEvent *`]
 ///
@@ -20,6 +23,28 @@ use std::ptr::NonNull;
 pub enum InputEvent {
     MotionEvent(MotionEvent),
     KeyEvent(KeyEvent),
+}
+
+/// Wraps a Java [`InputEvent`] acquired from [`KeyEvent::from_java()`] or
+/// [`MotionEvent::from_java()`] with respective [`Drop`] semantics.
+#[cfg(feature = "api-level-31")]
+#[derive(Debug)]
+pub struct InputEventJava(InputEvent);
+
+#[cfg(feature = "api-level-31")]
+impl Drop for InputEventJava {
+    /// Releases interface objects created by [`KeyEvent::from_java()`] or
+    /// [`MotionEvent::from_java()`].
+    ///
+    /// The underlying Java object remains valid and does not change its state.
+    #[doc(alias = "AInputEvent_release")]
+    fn drop(&mut self) {
+        let ptr = match self.0 {
+            InputEvent::MotionEvent(MotionEvent { ptr })
+            | InputEvent::KeyEvent(KeyEvent { ptr }) => ptr.as_ptr().cast(),
+        };
+        unsafe { ffi::AInputEvent_release(ptr) }
+    }
 }
 
 /// An enum representing the source of an [`InputEvent`].
@@ -373,7 +398,26 @@ impl MotionEvent {
         Self { ptr }
     }
 
-    /// Returns a pointer to the native [`ffi::AInputEvent`]
+    /// Creates a native [`InputEvent`] object that is a copy of the specified
+    /// Java [`android.view.MotionEvent`]. The result may be used with generic and
+    /// [`MotionEvent`]-specific functions.
+    ///
+    /// # Safety
+    ///
+    /// This function should be called with a healthy JVM pointer and with a non-null
+    /// [`android.view.MotionEvent`].
+    ///
+    /// [`android.view.MotionEvent`]: https://developer.android.com/reference/android/view/MotionEvent
+    #[cfg(feature = "api-level-31")]
+    #[doc(alias = "AMotionEvent_fromJava")]
+    pub unsafe fn from_java(env: *mut JNIEnv, key_event: jobject) -> Option<InputEventJava> {
+        let ptr = unsafe { ffi::AMotionEvent_fromJava(env, key_event) };
+        Some(InputEventJava(InputEvent::MotionEvent(Self::from_ptr(
+            NonNull::new(ptr.cast_mut())?,
+        ))))
+    }
+
+    /// Returns a pointer to the native [`ffi::AInputEvent`].
     #[inline]
     pub fn ptr(&self) -> NonNull<ffi::AInputEvent> {
         self.ptr
@@ -1342,7 +1386,26 @@ impl KeyEvent {
         Self { ptr }
     }
 
-    /// Returns a pointer to the native [`ffi::AInputEvent`]
+    /// Creates a native [`InputEvent`] object that is a copy of the specified Java
+    /// [`android.view.KeyEvent`]. The result may be used with generic and [`KeyEvent`]-specific
+    /// functions.
+    ///
+    /// # Safety
+    ///
+    /// This function should be called with a healthy JVM pointer and with a non-null
+    /// [`android.view.KeyEvent`].
+    ///
+    /// [`android.view.KeyEvent`]: https://developer.android.com/reference/android/view/KeyEvent
+    #[cfg(feature = "api-level-31")]
+    #[doc(alias = "AKeyEvent_fromJava")]
+    pub unsafe fn from_java(env: *mut JNIEnv, key_event: jobject) -> Option<InputEventJava> {
+        let ptr = unsafe { ffi::AKeyEvent_fromJava(env, key_event) };
+        Some(InputEventJava(InputEvent::KeyEvent(Self::from_ptr(
+            NonNull::new(ptr.cast_mut())?,
+        ))))
+    }
+
+    /// Returns a pointer to the native [`ffi::AInputEvent`].
     #[inline]
     pub fn ptr(&self) -> NonNull<ffi::AInputEvent> {
         self.ptr


### PR DESCRIPTION
These were added in API 31 (`KeyEvent`/`MotionEvent`) and API 33 (`InputEvent`), but not yet mapped in the NDK crate.
