### PR TITLE
ndk/image_reader: Special-case return statuses in `Image`-acquire functions

### DIFF
--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -15,6 +15,8 @@
 - Drop previous `Box`ed callbacks _after_ registering new ones, instead of before. (#455)
 - input_queue: Add `from_java()` constructor, available since API level 33. (#456)
 - event: Add `from_java()` constructors to `KeyEvent` and `MotionEvent`, available since API level 31. (#456)
+- **Breaking:** image_reader: Special-case return statuses in `Image`-acquire functions. (#457)
+- **Breaking:** image_reader: Mark `ImageReader::acquire_latest_image_async()` `unsafe` to match the safety requirements on `ImageReader::acquire_next_image_async()`. (#457)
 - event: Implement `SourceClass` `bitflag` and provide `Source::class()` getter. (#458)
 - Ensure all `bitflags` implementations consider all (including unknown) bits in negation and `all()`. (#458)
 - **Breaking:** Mark all enums as `non_exhaustive` and fix `repr` types. (#459)

--- a/ndk/src/media_error.rs
+++ b/ndk/src/media_error.rs
@@ -62,10 +62,6 @@ pub enum MediaError {
     DrmLicenseExpired = ffi::media_status_t::AMEDIA_DRM_LICENSE_EXPIRED.0,
     #[doc(alias = "AMEDIA_IMGREADER_ERROR_BASE")]
     ImgreaderErrorBase = ffi::media_status_t::AMEDIA_IMGREADER_ERROR_BASE.0,
-    #[doc(alias = "AMEDIA_IMGREADER_NO_BUFFER_AVAILABLE")]
-    ImgreaderNoBufferAvailable = ffi::media_status_t::AMEDIA_IMGREADER_NO_BUFFER_AVAILABLE.0,
-    #[doc(alias = "AMEDIA_IMGREADER_MAX_IMAGES_ACQUIRED")]
-    ImgreaderMaxImagesAcquired = ffi::media_status_t::AMEDIA_IMGREADER_MAX_IMAGES_ACQUIRED.0,
     #[doc(alias = "AMEDIA_IMGREADER_CANNOT_LOCK_IMAGE")]
     ImgreaderCannotLockImage = ffi::media_status_t::AMEDIA_IMGREADER_CANNOT_LOCK_IMAGE.0,
     #[doc(alias = "AMEDIA_IMGREADER_CANNOT_UNLOCK_IMAGE")]
@@ -136,10 +132,9 @@ pub(crate) fn construct_never_null<T>(
     with_ptr: impl FnOnce(*mut *mut T) -> ffi::media_status_t,
 ) -> Result<NonNull<T>> {
     let result = construct(with_ptr)?;
-    let non_null = if cfg!(debug_assertions) {
+    Ok(if cfg!(debug_assertions) {
         NonNull::new(result).expect("result should never be null")
     } else {
         unsafe { NonNull::new_unchecked(result) }
-    };
-    Ok(non_null)
+    })
 }


### PR DESCRIPTION
Both async and non-async `acquire_next/latest_image()` functions will return `ImgreaderNoBufferAvailable` when the producer has not provided a buffer that is either ready for consumption or that can be blocked on (either inside a non-async method, or by returning the accompanying fence file descriptor).  But only the non-`_async()` functions were marked as if this is a common case by returning an `Option<>`, seemingly out of the assumption that the `_async()` functions can _always_ give you an image (if the `MaxImagesAcquired` limit is not reached) but with a file-descriptor sync fence to wait on.  This is not the case as the producer needs to submit a buffer together with a sync fence on the producer-end first.

Hence the current API signatures create the false assumption that only non-async functions can "not have a buffer available at all", when the exact same is true for `_async()` functions, in order to provide an image buffer with a fence that is signalled when it is ready for reading.

Instead of special-casing this error in the `_async()` functions, special-case both `NoBufferAvailable` and `MaxImagesAcquired` in a new `enum AcquireResult` and let it be returned by both non-async and async functions.