### PR TITLE
ndk/event: Implement `SourceClass` `bitflag` and provide `Source::class()` getter

### DIFF
--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -4,6 +4,7 @@
 - media_format: Expose `MediaFormat::copy()` and `MediaFormat::clear()` from API level 29. (#449)
 - input_queue: Add `from_java()` constructor, available since API level 33. (#456)
 - event: Add `from_java()` constructors to `KeyEvent` and `MotionEvent`, available since API level 31. (#456)
+- event: Implement `SourceClass` `bitflag` and provide `Source::class()` getter. (#458)
 
 # 0.8.0 (2023-10-15)
 

--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -5,6 +5,7 @@
 - input_queue: Add `from_java()` constructor, available since API level 33. (#456)
 - event: Add `from_java()` constructors to `KeyEvent` and `MotionEvent`, available since API level 31. (#456)
 - event: Implement `SourceClass` `bitflag` and provide `Source::class()` getter. (#458)
+- Ensure all `bitflags` implementations consider all (including unknown) bits in negation and `all()`. (#458)
 
 # 0.8.0 (2023-10-15)
 

--- a/ndk/Cargo.toml
+++ b/ndk/Cargo.toml
@@ -36,7 +36,7 @@ api-level-33 = ["api-level-32"]
 test = ["ffi/test", "jni", "all"]
 
 [dependencies]
-bitflags = "2.2"
+bitflags = "2.4" # At least 2.4.0 for `const _ = !0`
 jni-sys = "0.3"
 log = "0.4.6"
 num_enum = "0.7"

--- a/ndk/src/event.rs
+++ b/ndk/src/event.rs
@@ -72,18 +72,28 @@ pub enum Source {
     Any = ffi::AINPUT_SOURCE_ANY,
 }
 
-/// An enum representing the class of an [`InputEvent`] source.
-///
-/// See [the NDK docs](https://developer.android.com/ndk/reference/group/input#anonymous-enum-35)
-#[derive(Debug, Clone, Copy, PartialEq, Eq, TryFromPrimitive, IntoPrimitive)]
-#[repr(u32)]
-enum Class {
-    None = ffi::AINPUT_SOURCE_CLASS_NONE,
-    Button = ffi::AINPUT_SOURCE_CLASS_BUTTON,
-    Pointer = ffi::AINPUT_SOURCE_CLASS_POINTER,
-    Navigation = ffi::AINPUT_SOURCE_CLASS_NAVIGATION,
-    Position = ffi::AINPUT_SOURCE_CLASS_POSITION,
-    Joystick = ffi::AINPUT_SOURCE_CLASS_JOYSTICK,
+impl Source {
+    pub fn class(self) -> SourceClass {
+        let class = u32::from(self) & ffi::AINPUT_SOURCE_CLASS_MASK;
+        SourceClass::from_bits_retain(class)
+    }
+}
+
+bitflags::bitflags! {
+    /// Flags representing the class of an [`InputEvent`] [`Source`].
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct SourceClass : u32 {
+        #[doc(alias = "AINPUT_SOURCE_CLASS_BUTTON")]
+        const BUTTON = ffi::AINPUT_SOURCE_CLASS_BUTTON;
+        #[doc(alias = "AINPUT_SOURCE_CLASS_POINTER")]
+        const POINTER = ffi::AINPUT_SOURCE_CLASS_POINTER;
+        #[doc(alias = "AINPUT_SOURCE_CLASS_NAVIGATION")]
+        const NAVIGATION = ffi::AINPUT_SOURCE_CLASS_NAVIGATION;
+        #[doc(alias = "AINPUT_SOURCE_CLASS_POSITION")]
+        const POSITION = ffi::AINPUT_SOURCE_CLASS_POSITION;
+        #[doc(alias = "AINPUT_SOURCE_CLASS_JOYSTICK")]
+        const JOYSTICK = ffi::AINPUT_SOURCE_CLASS_JOYSTICK;
+    }
 }
 
 impl InputEvent {

--- a/ndk/src/event.rs
+++ b/ndk/src/event.rs
@@ -75,24 +75,28 @@ pub enum Source {
 impl Source {
     pub fn class(self) -> SourceClass {
         let class = u32::from(self) & ffi::AINPUT_SOURCE_CLASS_MASK;
-        SourceClass::from_bits_retain(class)
+        // The mask fits in a u8.
+        SourceClass::from_bits_retain(class as u8)
     }
 }
 
 bitflags::bitflags! {
     /// Flags representing the class of an [`InputEvent`] [`Source`].
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-    pub struct SourceClass : u32 {
+    pub struct SourceClass : u8 {
         #[doc(alias = "AINPUT_SOURCE_CLASS_BUTTON")]
-        const BUTTON = ffi::AINPUT_SOURCE_CLASS_BUTTON;
+        const BUTTON = ffi::AINPUT_SOURCE_CLASS_BUTTON as u8;
         #[doc(alias = "AINPUT_SOURCE_CLASS_POINTER")]
-        const POINTER = ffi::AINPUT_SOURCE_CLASS_POINTER;
+        const POINTER = ffi::AINPUT_SOURCE_CLASS_POINTER as u8;
         #[doc(alias = "AINPUT_SOURCE_CLASS_NAVIGATION")]
-        const NAVIGATION = ffi::AINPUT_SOURCE_CLASS_NAVIGATION;
+        const NAVIGATION = ffi::AINPUT_SOURCE_CLASS_NAVIGATION as u8;
         #[doc(alias = "AINPUT_SOURCE_CLASS_POSITION")]
-        const POSITION = ffi::AINPUT_SOURCE_CLASS_POSITION;
+        const POSITION = ffi::AINPUT_SOURCE_CLASS_POSITION as u8;
         #[doc(alias = "AINPUT_SOURCE_CLASS_JOYSTICK")]
-        const JOYSTICK = ffi::AINPUT_SOURCE_CLASS_JOYSTICK;
+        const JOYSTICK = ffi::AINPUT_SOURCE_CLASS_JOYSTICK as u8;
+
+        // https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags
+        const _ = ffi::AINPUT_SOURCE_CLASS_MASK as u8;
     }
 }
 

--- a/ndk/src/looper.rs
+++ b/ndk/src/looper.rs
@@ -9,7 +9,6 @@
 //!
 //! [`ALooper`]: https://developer.android.com/ndk/reference/group/looper#alooper
 
-use bitflags::bitflags;
 use std::mem::ManuallyDrop;
 use std::os::{
     fd::{AsRawFd, BorrowedFd, RawFd},
@@ -31,12 +30,12 @@ pub struct ThreadLooper {
     foreign: ForeignLooper,
 }
 
-bitflags! {
+bitflags::bitflags! {
     /// Flags for file descriptor events that a looper can monitor.
     ///
     /// These flag bits can be combined to monitor multiple events at once.
     #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-    pub struct FdEvent: u32 {
+    pub struct FdEvent : u32 {
         /// The file descriptor is available for read operations.
         #[doc(alias = "ALOOPER_EVENT_INPUT")]
         const INPUT = ffi::ALOOPER_EVENT_INPUT;
@@ -65,6 +64,9 @@ bitflags! {
         /// necessary to specify this event flag in the requested event set.
         #[doc(alias = "ALOOPER_EVENT_INVALID")]
         const INVALID = ffi::ALOOPER_EVENT_INVALID;
+
+        // https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags
+        const _ = !0;
     }
 }
 

--- a/ndk/src/native_activity.rs
+++ b/ndk/src/native_activity.rs
@@ -3,7 +3,6 @@
 //! [`ANativeActivity`]: https://developer.android.com/ndk/reference/group/native-activity#anativeactivity
 
 use super::hardware_buffer_format::HardwareBufferFormat;
-use bitflags::bitflags;
 use std::{
     ffi::{CStr, OsStr},
     os::{raw::c_void, unix::prelude::OsStrExt},
@@ -11,14 +10,14 @@ use std::{
     ptr::NonNull,
 };
 
-bitflags! {
+bitflags::bitflags! {
     /// Window flags, as per the Java API at [`android.view.WindowManager.LayoutParams`].
     ///
     /// <https://developer.android.com/ndk/reference/group/native-activity#group___native_activity_1ga2f1398dba5e4a5616b83437528bdb28e>
     ///
     /// [`android.view.WindowManager.LayoutParams`]: https://developer.android.com/reference/android/view/WindowManager.LayoutParams
     #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-    pub struct WindowFlags: u32 {
+    pub struct WindowFlags : u32 {
         const ALLOW_LOCK_WHILE_SCREEN_ON = ffi::AWINDOW_FLAG_ALLOW_LOCK_WHILE_SCREEN_ON;
         const DIM_BEHIND = ffi::AWINDOW_FLAG_DIM_BEHIND;
         #[deprecated = "Deprecated. Blurring is no longer supported."]
@@ -48,6 +47,9 @@ bitflags! {
         #[cfg_attr(feature = "api-level-26", deprecated = "This constant was deprecated in API level 26. Use `SHOW_WHEN_LOCKED` instead.")]
         const DISMISS_KEYGUARD = ffi::AWINDOW_FLAG_DISMISS_KEYGUARD;
         const ATTACHED_IN_DECOR = 0x40000000;
+
+        // https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags
+        const _ = !0;
     }
 }
 

--- a/ndk/src/native_window.rs
+++ b/ndk/src/native_window.rs
@@ -422,6 +422,9 @@ bitflags::bitflags! {
         const TRANSFORM_ROTATE_180 = ffi::ANativeWindowTransform::ANATIVEWINDOW_TRANSFORM_ROTATE_180.0;
         #[doc(alias = "ANATIVEWINDOW_TRANSFORM_ROTATE_270")]
         const TRANSFORM_ROTATE_270 = ffi::ANativeWindowTransform::ANATIVEWINDOW_TRANSFORM_ROTATE_270.0;
+
+        // https://docs.rs/bitflags/latest/bitflags/#externally-defined-flags
+        const _ = !0;
     }
 }
 


### PR DESCRIPTION
This `enum` was never `pub` even though it serves a slight purpose to more easily classify various event sources, which is accounted for in the bitmask-like value of `AINPUT_SOURCE_XXX`.
