### PR TITLE
ndk/hardware_buffer: Convert `HardwareBufferUsage` to `bitflags`

### DIFF
--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Ensure all `bitflags` implementations consider all (including unknown) bits in negation and `all()`. (#458)
 - **Breaking:** Mark all enums as `non_exhaustive` and fix `repr` types. (#459)
 - **Breaking:** native_window: Remove redundant `TRANSFORM_` prefix from `NativeWindowTransform` variants. (#460)
+- **Breaking:** hardware_buffer: Convert `HardwareBufferUsage` to `bitflags`. (#461)
 - bitmap: Guard `BitmapCompressError` behind missing `api-level-30` feature. (#462)
 - data_space: Add missing `DataSpaceRange::Unspecified` variant. (#468)
 

--- a/ndk/src/hardware_buffer.rs
+++ b/ndk/src/hardware_buffer.rs
@@ -19,87 +19,180 @@ use jni_sys::{jobject, JNIEnv};
 
 use super::{hardware_buffer_format::HardwareBufferFormat, utils::status_to_io_result};
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct HardwareBufferUsage(pub ffi::AHardwareBuffer_UsageFlags);
+bitflags::bitflags! {
+    /// Buffer usage flags, specifying how the buffer will be accessed.
+    #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+    #[doc(alias = "AHardwareBuffer_UsageFlags")]
+    pub struct HardwareBufferUsage : u64 {
+        /// The buffer will never be locked for direct CPU reads using the
+        /// [`HardwareBuffer::lock()`] function. Note that reading the buffer using OpenGL or Vulkan
+        /// functions or memory mappings is still allowed.
+        #[doc(alias = "AHARDWAREBUFFER_USAGE_CPU_READ_NEVER")]
+        const CPU_READ_NEVER = ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_CPU_READ_NEVER.0;
+        /// The buffer will sometimes be locked for direct CPU reads using the
+        /// [`HardwareBuffer::lock()`] function. Note that reading the buffer using OpenGL or Vulkan
+        /// functions or memory mappings does not require the presence of this flag.
+        #[doc(alias = "AHARDWAREBUFFER_USAGE_CPU_READ_RARELY")]
+        const CPU_READ_RARELY = ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_CPU_READ_RARELY.0;
+        /// The buffer will often be locked for direct CPU reads using the
+        /// [`HardwareBuffer::lock()`] function. Note that reading the buffer using OpenGL or Vulkan
+        /// functions or memory mappings does not require the presence of this flag.
+        #[doc(alias = "AHARDWAREBUFFER_USAGE_CPU_READ_OFTEN")]
+        const CPU_READ_OFTEN = ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_CPU_READ_OFTEN.0;
+        /// CPU read value mask.
+        #[doc(alias = "AHARDWAREBUFFER_USAGE_CPU_READ_MASK")]
+        const CPU_READ_MASK = ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_CPU_READ_MASK.0;
+
+        /// The buffer will never be locked for direct CPU writes using the
+        /// [`HardwareBuffer::lock()`] function. Note that writing the buffer using OpenGL or Vulkan
+        /// functions or memory mappings is still allowed.
+        #[doc(alias = "AHARDWAREBUFFER_USAGE_CPU_WRITE_NEVER")]
+        const CPU_WRITE_NEVER = ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_CPU_WRITE_NEVER.0;
+        /// The buffer will sometimes be locked for direct CPU writes using the
+        /// [`HardwareBuffer::lock()`] function. Note that writing the buffer using OpenGL or Vulkan
+        /// functions or memory mappings does not require the presence of this flag.
+        #[doc(alias = "AHARDWAREBUFFER_USAGE_CPU_WRITE_RARELY")]
+        const CPU_WRITE_RARELY = ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_CPU_WRITE_RARELY.0;
+        /// The buffer will often be locked for direct CPU writes using the
+        /// [`HardwareBuffer::lock()`] function. Note that writing the buffer using OpenGL or Vulkan
+        /// functions or memory mappings does not require the presence of this flag.
+        #[doc(alias = "AHARDWAREBUFFER_USAGE_CPU_WRITE_OFTEN")]
+        const CPU_WRITE_OFTEN = ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_CPU_WRITE_OFTEN.0;
+        /// CPU write value mask.
+        #[doc(alias = "AHARDWAREBUFFER_USAGE_CPU_WRITE_MASK")]
+        const CPU_WRITE_MASK = ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_CPU_WRITE_MASK.0;
+
+        /// The buffer will be read from by the GPU as a texture.
+        #[doc(alias = "AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE")]
+        const GPU_SAMPLED_IMAGE = ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE.0;
+        /// The buffer will be written to by the GPU as a framebuffer attachment.
+        #[doc(alias = "AHARDWAREBUFFER_USAGE_GPU_FRAMEBUFFER")]
+        const GPU_FRAMEBUFFER = ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_GPU_FRAMEBUFFER.0;
+        /// The buffer will be written to by the GPU as a framebuffer attachment.
+        ///
+        /// Note that the name of this flag is somewhat misleading: it does not imply that the
+        /// buffer contains a color format. A buffer with depth or stencil format that will be
+        /// used as a framebuffer attachment should also have this flag. Use the equivalent flag
+        /// [`HardwareBufferusage::GPU_FRAMEBUFFER`] to avoid this confusion.
+        #[doc(alias = "AHARDWAREBUFFER_USAGE_GPU_COLOR_OUTPUT")]
+        const GPU_COLOR_OUTPUT = ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_GPU_COLOR_OUTPUT.0;
+        /// The buffer will be used as a composer HAL overlay layer.
+        ///
+        /// This flag is currently only needed when using [`SurfaceTransaction::set_buffer()`] to
+        /// set a buffer. In all other cases, the framework adds this flag internally to buffers
+        /// that could be presented in a composer overlay. [`SurfaceTransaction::set_buffer()`]
+        /// is special because it uses buffers allocated directly through
+        /// [`HardwareBuffer::allocate()`] instead of buffers allocated by the framework.
+        #[doc(alias = "AHARDWAREBUFFER_USAGE_COMPOSER_OVERLAY")]
+        const COMPOSER_OVERLAY = ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_COMPOSER_OVERLAY.0;
+        /// The buffer is protected from direct CPU access or being read by non-secure hardware,
+        /// such as video encoders.
+        ///
+        /// This flag is incompatible with CPU read and write flags. It is mainly used when handling
+        /// DRM video. Refer to the EGL extension [`EGL_EXT_protected_content`] and GL extension
+        /// [`GL_EXT_protected_textures`] for more information on how these buffers are expected
+        /// to behave.
+        ///
+        /// [`EGL_EXT_protected_content`]: https://registry.khronos.org/EGL/extensions/EXT/EGL_EXT_protected_content.txt
+        /// [`GL_EXT_protected_textures`]: https://registry.khronos.org/OpenGL/extensions/EXT/EXT_protected_textures.txt
+        #[doc(alias = "AHARDWAREBUFFER_USAGE_PROTECTED_CONTENT")]
+        const PROTECTED_CONTENT = ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_PROTECTED_CONTENT.0;
+        /// The buffer will be read by a hardware video encoder.
+        #[doc(alias = "AHARDWAREBUFFER_USAGE_VIDEO_ENCODE")]
+        const VIDEO_ENCODE = ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_VIDEO_ENCODE.0;
+        /// The buffer will be used for direct writes from sensors. When this flag is present, the
+        /// format must be [`HardwareBufferFormat::Blob`].
+        #[doc(alias = "AHARDWAREBUFFER_USAGE_SENSOR_DIRECT_DATA")]
+        const SENSOR_DIRECT_DATA = ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_SENSOR_DIRECT_DATA.0;
+        /// The buffer will be used as a shader storage or uniform buffer object. When this flag is
+        /// present, the format must be [`HardwareBufferFormat::Blob`].
+        #[doc(alias = "AHARDWAREBUFFER_USAGE_GPU_DATA_BUFFER")]
+        const GPU_DATA_BUFFER = ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_GPU_DATA_BUFFER.0;
+        /// The buffer will be used as a cube map texture. When this flag is present, the buffer
+        /// must have a layer count that is a multiple of 6. Note that buffers with this flag must
+        /// be bound to OpenGL textures using the extension [`GL_EXT_EGL_image_storage`] instead
+        /// of [`GL_KHR_EGL_image`].
+        ///
+        /// [`GL_EXT_EGL_image_storage`]: https://registry.khronos.org/OpenGL/extensions/EXT/EXT_EGL_image_storage.txt
+        // TODO: This extension only exists for VG. Reported at https://issuetracker.google.com/issues/300602767#comment16
+        /// [`GL_KHR_EGL_image`]: https://registry.khronos.org/OpenVG/extensions/KHR/VG_KHR_EGL_image.txt
+        #[doc(alias = "AHARDWAREBUFFER_USAGE_GPU_CUBE_MAP")]
+        const GPU_CUBE_MAP = ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_GPU_CUBE_MAP.0;
+        /// The buffer contains a complete mipmap hierarchy. Note that buffers with this flag must
+        /// be bound to OpenGL textures using the extension [`GL_EXT_EGL_image_storage`] instead
+        /// of [`GL_KHR_EGL_image`].
+        ///
+        /// [`GL_EXT_EGL_image_storage`]: https://registry.khronos.org/OpenGL/extensions/EXT/EXT_EGL_image_storage.txt
+        // TODO: This extension only exists for VG. Reported at https://issuetracker.google.com/issues/300602767#comment16
+        /// [`GL_KHR_EGL_image`]: https://registry.khronos.org/OpenVG/extensions/KHR/VG_KHR_EGL_image.txt
+        #[doc(alias = "AHARDWAREBUFFER_USAGE_GPU_MIPMAP_COMPLETE")]
+        const GPU_MIPMAP_COMPLETE = ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_GPU_MIPMAP_COMPLETE.0;
+
+        // TODO: Only available in a newer NDK
+        // /// Usage: The buffer is used for front-buffer rendering. When front-buffering rendering
+        // /// is specified, different usages may adjust their behavior as a result. For example, when
+        // /// used as [`HardwareBufferFormat::GPU_COLOR_OUTPUT`] the buffer will behave similar to a
+        // /// single-buffered window. When used with [`HardwareBufferFormat::COMPOSER_OVERLAY`], the
+        // /// system will try to prioritize the buffer receiving an overlay plane & avoid caching it
+        // /// in intermediate composition buffers.
+        // #[doc(alias = "AHARDWAREBUFFER_USAGE_FRONT_BUFFER")]
+        // const USAGE_FRONT_BUFFER = ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_FRONT_BUFFER.0;
+
+        #[doc(alias = "AHARDWAREBUFFER_USAGE_VENDOR_0")]
+        const VENDOR_0 = ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_VENDOR_0.0;
+        #[doc(alias = "AHARDWAREBUFFER_USAGE_VENDOR_1")]
+        const VENDOR_1 = ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_VENDOR_1.0;
+        #[doc(alias = "AHARDWAREBUFFER_USAGE_VENDOR_2")]
+        const VENDOR_2 = ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_VENDOR_2.0;
+        #[doc(alias = "AHARDWAREBUFFER_USAGE_VENDOR_3")]
+        const VENDOR_3 = ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_VENDOR_3.0;
+        #[doc(alias = "AHARDWAREBUFFER_USAGE_VENDOR_4")]
+        const VENDOR_4 = ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_VENDOR_4.0;
+        #[doc(alias = "AHARDWAREBUFFER_USAGE_VENDOR_5")]
+        const VENDOR_5 = ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_VENDOR_5.0;
+        #[doc(alias = "AHARDWAREBUFFER_USAGE_VENDOR_6")]
+        const VENDOR_6 = ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_VENDOR_6.0;
+        #[doc(alias = "AHARDWAREBUFFER_USAGE_VENDOR_7")]
+        const VENDOR_7 = ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_VENDOR_7.0;
+        #[doc(alias = "AHARDWAREBUFFER_USAGE_VENDOR_8")]
+        const VENDOR_8 = ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_VENDOR_8.0;
+        #[doc(alias = "AHARDWAREBUFFER_USAGE_VENDOR_9")]
+        const VENDOR_9 = ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_VENDOR_9.0;
+        #[doc(alias = "AHARDWAREBUFFER_USAGE_VENDOR_10")]
+        const VENDOR_10 = ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_VENDOR_10.0;
+        #[doc(alias = "AHARDWAREBUFFER_USAGE_VENDOR_11")]
+        const VENDOR_11 = ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_VENDOR_11.0;
+        #[doc(alias = "AHARDWAREBUFFER_USAGE_VENDOR_12")]
+        const VENDOR_12 = ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_VENDOR_12.0;
+        #[doc(alias = "AHARDWAREBUFFER_USAGE_VENDOR_13")]
+        const VENDOR_13 = ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_VENDOR_13.0;
+        #[doc(alias = "AHARDWAREBUFFER_USAGE_VENDOR_14")]
+        const VENDOR_14 = ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_VENDOR_14.0;
+        #[doc(alias = "AHARDWAREBUFFER_USAGE_VENDOR_15")]
+        const VENDOR_15 = ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_VENDOR_15.0;
+        #[doc(alias = "AHARDWAREBUFFER_USAGE_VENDOR_16")]
+        const VENDOR_16 = ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_VENDOR_16.0;
+        #[doc(alias = "AHARDWAREBUFFER_USAGE_VENDOR_17")]
+        const VENDOR_17 = ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_VENDOR_17.0;
+        #[doc(alias = "AHARDWAREBUFFER_USAGE_VENDOR_18")]
+        const VENDOR_18 = ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_VENDOR_18.0;
+        #[doc(alias = "AHARDWAREBUFFER_USAGE_VENDOR_19")]
+        const VENDOR_19 = ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_VENDOR_19.0;
+    }
+}
 
 impl HardwareBufferUsage {
-    pub const CPU_READ_NEVER: Self =
-        Self(ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_CPU_READ_NEVER);
-    pub const CPU_READ_RARELY: Self =
-        Self(ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_CPU_READ_RARELY);
-    pub const CPU_READ_OFTEN: Self =
-        Self(ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_CPU_READ_OFTEN);
-    pub const CPU_READ_MASK: Self =
-        Self(ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_CPU_READ_MASK);
+    /// Helper to read [`HardwareBufferUsage::CPU_READ_MASK`] values.
+    #[doc(alias = "AHARDWAREBUFFER_USAGE_CPU_READ_MASK")]
+    pub fn cpu_read(self) -> HardwareBufferUsage {
+        self.intersection(Self::CPU_READ_MASK)
+    }
 
-    pub const CPU_WRITE_NEVER: Self =
-        Self(ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_CPU_WRITE_NEVER);
-    pub const CPU_WRITE_RARELY: Self =
-        Self(ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_CPU_WRITE_RARELY);
-    pub const CPU_WRITE_OFTEN: Self =
-        Self(ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_CPU_WRITE_OFTEN);
-    pub const CPU_WRITE_MASK: Self =
-        Self(ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_CPU_WRITE_MASK);
-
-    pub const GPU_SAMPLED_IMAGE: Self =
-        Self(ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE);
-    pub const GPU_FRAMEBUFFER: Self =
-        Self(ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_GPU_FRAMEBUFFER);
-    pub const COMPOSER_OVERLAY: Self =
-        Self(ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_COMPOSER_OVERLAY);
-    pub const PROTECTED_CONTENT: Self =
-        Self(ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_PROTECTED_CONTENT);
-    pub const VIDEO_ENCODE: Self =
-        Self(ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_VIDEO_ENCODE);
-    pub const SENSOR_DIRECT_DATA: Self =
-        Self(ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_SENSOR_DIRECT_DATA);
-    pub const GPU_DATA_BUFFER: Self =
-        Self(ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_GPU_DATA_BUFFER);
-    pub const GPU_CUBE_MAP: Self =
-        Self(ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_GPU_CUBE_MAP);
-    pub const GPU_MIPMAP_COMPLETE: Self =
-        Self(ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_GPU_MIPMAP_COMPLETE);
-
-    pub const VENDOR_0: Self =
-        Self(ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_VENDOR_0);
-    pub const VENDOR_1: Self =
-        Self(ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_VENDOR_1);
-    pub const VENDOR_2: Self =
-        Self(ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_VENDOR_2);
-    pub const VENDOR_3: Self =
-        Self(ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_VENDOR_3);
-    pub const VENDOR_4: Self =
-        Self(ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_VENDOR_4);
-    pub const VENDOR_5: Self =
-        Self(ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_VENDOR_5);
-    pub const VENDOR_6: Self =
-        Self(ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_VENDOR_6);
-    pub const VENDOR_7: Self =
-        Self(ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_VENDOR_7);
-    pub const VENDOR_8: Self =
-        Self(ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_VENDOR_8);
-    pub const VENDOR_9: Self =
-        Self(ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_VENDOR_9);
-    pub const VENDOR_10: Self =
-        Self(ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_VENDOR_10);
-    pub const VENDOR_11: Self =
-        Self(ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_VENDOR_11);
-    pub const VENDOR_12: Self =
-        Self(ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_VENDOR_12);
-    pub const VENDOR_13: Self =
-        Self(ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_VENDOR_13);
-    pub const VENDOR_14: Self =
-        Self(ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_VENDOR_14);
-    pub const VENDOR_15: Self =
-        Self(ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_VENDOR_15);
-    pub const VENDOR_16: Self =
-        Self(ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_VENDOR_16);
-    pub const VENDOR_17: Self =
-        Self(ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_VENDOR_17);
-    pub const VENDOR_18: Self =
-        Self(ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_VENDOR_18);
-    pub const VENDOR_19: Self =
-        Self(ffi::AHardwareBuffer_UsageFlags::AHARDWAREBUFFER_USAGE_VENDOR_19);
+    /// Helper to read [`HardwareBufferUsage::CPU_WRITE_MASK`] values.
+    #[doc(alias = "AHARDWAREBUFFER_USAGE_CPU_WRITE_MASK")]
+    pub fn cpu_write(self) -> HardwareBufferUsage {
+        self.intersection(Self::CPU_WRITE_MASK)
+    }
 }
 
 pub type Rect = ffi::ARect;
@@ -213,7 +306,7 @@ impl HardwareBuffer {
             format: i32::try_from(desc.format)
                 .expect("i32->u32 overflow in HardwareBuffer::describe()")
                 .into(),
-            usage: HardwareBufferUsage(ffi::AHardwareBuffer_UsageFlags(desc.usage)),
+            usage: HardwareBufferUsage::from_bits_retain(desc.usage),
             stride: desc.stride,
         }
     }
@@ -288,7 +381,7 @@ impl HardwareBuffer {
             None => std::ptr::null(),
         };
         construct(|res| unsafe {
-            ffi::AHardwareBuffer_lock(self.as_ptr(), usage.0 .0, fence, rect, res)
+            ffi::AHardwareBuffer_lock(self.as_ptr(), usage.bits(), fence, rect, res)
         })
     }
 
@@ -317,7 +410,7 @@ impl HardwareBuffer {
         let status = unsafe {
             ffi::AHardwareBuffer_lockAndGetInfo(
                 self.as_ptr(),
-                usage.0 .0,
+                usage.bits(),
                 fence,
                 rect,
                 virtual_address.as_mut_ptr(),
@@ -364,7 +457,7 @@ impl HardwareBuffer {
             None => std::ptr::null(),
         };
         let planes = construct(|res| unsafe {
-            ffi::AHardwareBuffer_lockPlanes(self.as_ptr(), usage.0 .0, fence, rect, res)
+            ffi::AHardwareBuffer_lockPlanes(self.as_ptr(), usage.bits(), fence, rect, res)
         })?;
 
         Ok(HardwareBufferPlanes {
@@ -501,7 +594,7 @@ impl HardwareBufferDesc {
             format: i32::from(self.format)
                 .try_into()
                 .expect("i32->u32 overflow in HardwareBufferDesc::into_native()"),
-            usage: self.usage.0 .0,
+            usage: self.usage.bits(),
             stride: self.stride,
             rfu0: 0,
             rfu1: 0,

--- a/ndk/src/media/image_reader.rs
+++ b/ndk/src/media/image_reader.rs
@@ -114,7 +114,7 @@ impl ImageReader {
                 width,
                 height,
                 format.into(),
-                usage.0 .0,
+                usage.bits(),
                 max_images,
                 res,
             )


### PR DESCRIPTION
`HardwareBufferUsage` really is a structure that comprises various usage flags, and was modeled as a hard-to-get `u64` value while being wrapped inside _two_ newtypes (one in the `ndk`, one in `ndk-sys`) and without the typical bit-ops (i.e. `BitOr`) one comes to expect.

This is all provided out of the box - and more helper functions - via `bitflags` with more convenient access to the raw value to beat.

Also inherit the upstream docs for convenience and completeness.