### PR TITLE
ndk/bitmap: Gate `BitmapCompressError` behind `api-level-30`

### DIFF
--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Move `MediaFormat` from `media::media_codec` to its own `media::media_format` module. (#442)
 - media_format: Expose `MediaFormat::copy()` and `MediaFormat::clear()` from API level 29. (#449)
-- ndk/bitmap: Fix missing `cfg(feature = "api-level-30")` on `BitmapCompressError` (#462)
+- ndk/bitmap: Guard `BitmapCompressError` behind missing `api-level-30` feature. (#462)
 
 # 0.8.0 (2023-10-15)
 

--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Move `MediaFormat` from `media::media_codec` to its own `media::media_format` module. (#442)
 - media_format: Expose `MediaFormat::copy()` and `MediaFormat::clear()` from API level 29. (#449)
+- ndk/bitmap: Fix missing `cfg(feature = "api-level-30")` on `BitmapCompressError` (#462)
 
 # 0.8.0 (2023-10-15)
 

--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Move `MediaFormat` from `media::media_codec` to its own `media::media_format` module. (#442)
 - media_format: Expose `MediaFormat::copy()` and `MediaFormat::clear()` from API level 29. (#449)
-- ndk/bitmap: Guard `BitmapCompressError` behind missing `api-level-30` feature. (#462)
+- bitmap: Guard `BitmapCompressError` behind missing `api-level-30` feature. (#462)
 
 # 0.8.0 (2023-10-15)
 

--- a/ndk/src/bitmap.rs
+++ b/ndk/src/bitmap.rs
@@ -9,7 +9,6 @@
 use jni_sys::{jobject, JNIEnv};
 use num_enum::{FromPrimitive, IntoPrimitive, TryFromPrimitive, TryFromPrimitiveError};
 use std::{error, fmt, mem::MaybeUninit};
-use thiserror::Error;
 
 #[cfg(feature = "api-level-30")]
 use crate::data_space::DataSpace;
@@ -481,7 +480,8 @@ pub enum BitmapCompressFormat {
 }
 
 /// Encapsulates possible errors returned by [`Bitmap::compress()`] or [`Bitmap::compress_raw()`].
-#[derive(Debug, Error)]
+#[cfg(feature = "api-level-30")]
+#[derive(Debug, thiserror::Error)]
 pub enum BitmapCompressError {
     #[error(transparent)]
     BitmapError(#[from] BitmapError),


### PR DESCRIPTION
Otherwise there is a compilation error when building with only the feature `bitmap`, due to the inexistence of the `DataSpace` type. `DataSpace` is defined with `api-level-28`, but this `BitmapCompressError` is only used by `Bitmap::compress()` and `Bitmap::compress_raw()`, which are only available with `api-level-30`.