### PR TITLE
ndk/native_window: Link against `libnativewindow` for API >= 26 functions

### DIFF
--- a/ndk-sys/CHANGELOG.md
+++ b/ndk-sys/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Add `nativewindow` feature to link against `libnativewindow`. (#465)
+
 # 0.5.0 (2023-10-15)
 
 - **Breaking:** Regenerate against NDK `25.2.9519653` with `rust-bindgen 0.66.0`. (#324, #370)

--- a/ndk-sys/Cargo.toml
+++ b/ndk-sys/Cargo.toml
@@ -20,6 +20,7 @@ test = []
 audio = []
 bitmap = []
 media = []
+nativewindow = []
 sync = []
 
 [package.metadata.docs.rs]

--- a/ndk-sys/src/lib.rs
+++ b/ndk-sys/src/lib.rs
@@ -40,6 +40,10 @@ include!("ffi_x86_64.rs");
 #[link(name = "android")]
 extern "C" {}
 
+#[cfg(all(feature = "nativewindow", target_os = "android"))]
+#[link(name = "nativewindow")]
+extern "C" {}
+
 #[cfg(all(feature = "media", target_os = "android"))]
 #[link(name = "mediandk")]
 extern "C" {}

--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -20,6 +20,7 @@
 - **Breaking:** Mark all enums as `non_exhaustive` and fix `repr` types. (#459)
 - **Breaking:** native_window: Remove redundant `TRANSFORM_` prefix from `NativeWindowTransform` variants. (#460)
 - bitmap: Guard `BitmapCompressError` behind missing `api-level-30` feature. (#462)
+- native_window: Require linking against `libnativewindow` for most API >= 26 functions. (#465)
 - data_space: Add missing `DataSpaceRange::Unspecified` variant. (#468)
 
 # 0.8.0 (2023-10-15)

--- a/ndk/Cargo.toml
+++ b/ndk/Cargo.toml
@@ -14,11 +14,12 @@ rust-version = "1.66"
 
 [features]
 default = ["rwh_06"]
-all = ["audio", "bitmap", "media", "sync", "api-level-33", "rwh_04", "rwh_05", "rwh_06"]
+all = ["audio", "bitmap", "media", "nativewindow", "sync", "api-level-33", "rwh_04", "rwh_05", "rwh_06"]
 
 audio = ["ffi/audio", "api-level-26"]
 bitmap = ["ffi/bitmap"]
 media = ["ffi/media"]
+nativewindow = ["ffi/nativewindow"]
 sync = ["ffi/sync", "api-level-26"]
 
 api-level-23 = []

--- a/ndk/src/native_window.rs
+++ b/ndk/src/native_window.rs
@@ -7,7 +7,7 @@ use std::{ffi::c_void, io, mem::MaybeUninit, ptr::NonNull};
 use jni_sys::{jobject, JNIEnv};
 
 use super::{hardware_buffer_format::HardwareBufferFormat, utils::status_to_io_result};
-#[cfg(feature = "api-level-28")]
+#[cfg(all(feature = "nativewindow", feature = "api-level-28"))]
 use crate::data_space::DataSpace;
 
 pub type Rect = ffi::ARect;
@@ -130,7 +130,8 @@ impl NativeWindow {
     }
 
     /// Set a transform that will be applied to future buffers posted to the window.
-    #[cfg(feature = "api-level-26")]
+    #[cfg(all(feature = "nativewindow", feature = "api-level-26"))]
+    #[doc(alias = "ANativeWindow_setBuffersTransform")]
     pub fn set_buffers_transform(&self, transform: NativeWindowTransform) -> io::Result<()> {
         let status =
             unsafe { ffi::ANativeWindow_setBuffersTransform(self.ptr.as_ptr(), transform.bits()) };
@@ -144,7 +145,7 @@ impl NativeWindow {
     /// to convey the color space of the image data in the buffer, or it can be used to indicate
     /// that the buffers contain depth measurement data instead of color images. The default
     /// dataSpace is `0`, [`DataSpace::Unknown`], unless it has been overridden by the producer.
-    #[cfg(feature = "api-level-28")]
+    #[cfg(all(feature = "nativewindow", feature = "api-level-28"))]
     #[doc(alias = "ANativeWindow_setBuffersDataSpace")]
     pub fn set_buffers_data_space(&self, data_space: DataSpace) -> io::Result<()> {
         let status =
@@ -153,7 +154,7 @@ impl NativeWindow {
     }
 
     /// Get the dataspace of the buffers in this [`NativeWindow`].
-    #[cfg(feature = "api-level-28")]
+    #[cfg(all(feature = "nativewindow", feature = "api-level-28"))]
     #[doc(alias = "ANativeWindow_getBuffersDataSpace")]
     pub fn buffers_data_space(&self) -> io::Result<DataSpace> {
         let status = unsafe { ffi::ANativeWindow_getBuffersDataSpace(self.ptr.as_ptr()) };
@@ -172,7 +173,7 @@ impl NativeWindow {
         not(feature = "api-level-31"),
         doc = "[`NativeWindow::set_frame_rate_with_change_strategy()`]: https://developer.android.com/ndk/reference/group/a-native-window#anativewindow_setframeratewithchangestrategy"
     )]
-    #[cfg(feature = "api-level-30")]
+    #[cfg(all(feature = "nativewindow", feature = "api-level-30"))]
     #[doc(alias = "ANativeWindow_setFrameRate")]
     pub fn set_frame_rate(
         &self,
@@ -215,7 +216,7 @@ impl NativeWindow {
     ///   window should be seamless. A seamless transition is one that doesn't have any visual
     ///   interruptions, such as a black screen for a second or two. See the
     ///   [`ChangeFrameRateStrategy`] values. This parameter is ignored when `frame_rate` is `0`.
-    #[cfg(feature = "api-level-31")]
+    #[cfg(all(feature = "nativewindow", feature = "api-level-31"))]
     #[doc(alias = "ANativeWindow_setFrameRateWithChangeStrategy")]
     pub fn set_frame_rate_with_change_strategy(
         &self,
@@ -239,7 +240,7 @@ impl NativeWindow {
     /// Note that the window implementation is not guaranteed to preallocate any buffers, for
     /// instance if an implementation disallows allocation of new buffers, or if there is
     /// insufficient memory in the system to preallocate additional buffers
-    #[cfg(feature = "api-level-30")]
+    #[cfg(all(feature = "nativewindow", feature = "api-level-30"))]
     pub fn try_allocate_buffers(&self) {
         unsafe { ffi::ANativeWindow_tryAllocateBuffers(self.ptr.as_ptr()) }
     }
@@ -377,7 +378,7 @@ impl<'a> Drop for NativeWindowBufferLockGuard<'a> {
     }
 }
 
-#[cfg(feature = "api-level-26")]
+#[cfg(all(feature = "nativewindow", feature = "api-level-26"))]
 bitflags::bitflags! {
     /// Transforms that can be applied to buffers as they are displayed to a window.
     ///
@@ -413,7 +414,7 @@ bitflags::bitflags! {
     doc = " and [`NativeWindow::set_frame_rate_with_change_strategy()`]"
 )]
 /// .
-#[cfg(feature = "api-level-30")]
+#[cfg(all(feature = "nativewindow", feature = "api-level-30"))]
 #[repr(i8)]
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 #[doc(alias = "ANativeWindow_FrameRateCompatibility")]
@@ -440,7 +441,7 @@ pub enum FrameRateCompatibility {
 }
 
 /// Change frame rate strategy value for [`NativeWindow::set_frame_rate_with_change_strategy()`].
-#[cfg(feature = "api-level-31")]
+#[cfg(all(feature = "nativewindow", feature = "api-level-31"))]
 #[repr(i8)]
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 #[doc(alias = "ANativeWindow_ChangeFrameRateStrategy")]


### PR DESCRIPTION
Per [the `libandroid` function map][1] newer `NativeWindow` functions are no longer available; these instead need to be linked [from the `libnativewindow` library][2] directly.

[1]: https://cs.android.com/android/platform/superproject/main/+/main:frameworks/base/native/android/libandroid.map.txt;l=1?q=libandroid.map.txt&sq=&ss=android%2Fplatform%2Fsuperproject%2Fmain
[2]: https://cs.android.com/android/platform/superproject/main/+/main:frameworks/native/libs/nativewindow/libnativewindow.map.txt;l=1?q=libnativewindow.map.txt&sq=&ss=android%2Fplatform%2Fsuperproject%2Fmain

Ref: https://github.com/android/ndk/issues/1982
