### PR TITLE
ndk/audio: Merge `AudioResult` variant enum into `AudioError`

### DIFF
--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -22,6 +22,7 @@
 - **Breaking:** hardware_buffer: Convert `HardwareBufferUsage` to `bitflags`. (#461)
 - bitmap: Guard `BitmapCompressError` behind missing `api-level-30` feature. (#462)
 - native_window: Require linking against `libnativewindow` for most API >= 26 functions. (#465)
+- **Breaking:** audio: Merge `AudioResult` variant enum into `AudioError`. (#467)
 - data_space: Add missing `DataSpaceRange::Unspecified` variant. (#468)
 
 # 0.8.0 (2023-10-15)


### PR DESCRIPTION
Depends on #459

Now that `UnsupportedValue` is no longer part of `AudioError` thanks to all enums having a proper `__Unknown(x)` catch-all (making the `enum` API a whole lot more convenient to users), this `#[error]` enum is just a wrapper struct with only one variant.

Instead, drop `AudioError` and its `thiserror` wrapping completely, and import `Error` directly on the `aaudio_result_t` `enum` that is also renamed to `AudioError`.
