### PR TITLE
ndk/data_space: Add missing `DataSpaceRange::Unspecified` variant

### DIFF
--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -7,6 +7,7 @@
 - event: Implement `SourceClass` `bitflag` and provide `Source::class()` getter. (#458)
 - Ensure all `bitflags` implementations consider all (including unknown) bits in negation and `all()`. (#458)
 - bitmap: Guard `BitmapCompressError` behind missing `api-level-30` feature. (#462)
+- data_space: Add missing `DataSpaceRange::Unspecified` variant. (#468)
 
 # 0.8.0 (2023-10-15)
 

--- a/ndk/src/data_space.rs
+++ b/ndk/src/data_space.rs
@@ -588,6 +588,17 @@ pub enum DataSpaceTransfer {
 #[doc(alias = "RANGE_MASK")]
 #[non_exhaustive]
 pub enum DataSpaceRange {
+    /// Range is unknown or are determined by the application.  Implementations shall use the
+    /// following suggested ranges:
+    ///
+    /// - All YCbCr formats: limited range.
+    /// - All RGB or RGBA formats (including RAW and Bayer): full range.
+    /// - All Y formats: full range
+    ///
+    /// For all other formats range is undefined, and implementations should use an appropriate
+    /// range for the data represented.
+    #[doc(alias = "RANGE_UNSPECIFIED")]
+    Unspecified = ffi::ADataSpace::RANGE_UNSPECIFIED.0,
     /// Full range uses all values for `Y`, `Cb` and `Cr` from `0` to `2^b-1`, where `b` is the bit
     /// depth of the color format.
     #[doc(alias = "RANGE_FULL")]


### PR DESCRIPTION
This variant corresponds to `0`.  This missing variant was found while `Debug`-printing a `DataSpace` with the `__Unknown` PR, where `DataSpace::Unknown` printed `__Unknown(0)` for the range "field".
