### PR TITLE
cargo: Add `categories` for discoverability

### DIFF
--- a/ndk-sys/Cargo.toml
+++ b/ndk-sys/Cargo.toml
@@ -11,6 +11,7 @@ documentation = "https://docs.rs/ndk-sys"
 homepage = "https://github.com/rust-mobile/ndk"
 repository = "https://github.com/rust-mobile/ndk"
 rust-version = "1.60"
+categories = ["os", "os::android-apis", "external-ffi-bindings"]
 
 [dependencies]
 jni-sys = "0.3.0"

--- a/ndk/Cargo.toml
+++ b/ndk/Cargo.toml
@@ -11,6 +11,7 @@ documentation = "https://docs.rs/ndk"
 homepage = "https://github.com/rust-mobile/ndk"
 repository = "https://github.com/rust-mobile/ndk"
 rust-version = "1.66"
+categories = ["os", "os::android-apis", "api-bindings"]
 
 [features]
 default = ["rwh_06"]


### PR DESCRIPTION
`os::android-apis` is a new category that I added upstream in https://github.com/rust-lang/crates.io/pull/8558.  The rest already exists on crates.io, and should make it easier to find/place this crate.
