### PR TITLE
image_reader: Add `AImageReader_newWithDataSpace()` from `api-level-34`

### DIFF
--- a/ndk/CHANGELOG.md
+++ b/ndk/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- image_reader: Add `ImageReader::new_with_data_space()` constructor and `ImageReader::data_space()` getter from API level 34. (#474)
+
 # 0.9.0 (2024-04-26)
 
 - Move `MediaFormat` from `media::media_codec` to its own `media::media_format` module. (#442)

--- a/ndk/Cargo.toml
+++ b/ndk/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.66"
 
 [features]
 default = ["rwh_06"]
-all = ["audio", "bitmap", "media", "nativewindow", "sync", "api-level-33", "rwh_04", "rwh_05", "rwh_06"]
+all = ["audio", "bitmap", "media", "nativewindow", "sync", "api-level-34", "rwh_04", "rwh_05", "rwh_06"]
 
 audio = ["ffi/audio", "api-level-26"]
 bitmap = ["ffi/bitmap"]
@@ -33,6 +33,7 @@ api-level-30 = ["api-level-29"]
 api-level-31 = ["api-level-30"]
 api-level-32 = ["api-level-31"]
 api-level-33 = ["api-level-32"]
+api-level-34 = ["api-level-33"]
 
 test = ["ffi/test", "jni", "all"]
 

--- a/ndk/src/hardware_buffer.rs
+++ b/ndk/src/hardware_buffer.rs
@@ -593,7 +593,7 @@ impl HardwareBufferDesc {
             layers: self.layers,
             format: i32::from(self.format)
                 .try_into()
-                .expect("i32->u32 overflow in HardwareBufferDesc::into_native()"),
+                .expect("Unexpected sign bit in `format`"),
             usage: self.usage.bits(),
             stride: self.stride,
             rfu0: 0,

--- a/ndk/src/surface_texture.rs
+++ b/ndk/src/surface_texture.rs
@@ -143,7 +143,7 @@ impl SurfaceTexture {
         Duration::from_nanos(
             unsafe { ffi::ASurfaceTexture_getTimestamp(self.ptr.as_ptr()) }
                 .try_into()
-                .unwrap(),
+                .expect("Timestamp cannot be negative"),
         )
     }
 


### PR DESCRIPTION
Android 14 (U, API level 34) adds `DataSpace` support to `ImageReader` with a new constructor and a getter, and finally switches to the regular `HardwareBufferFormat` instead of the restricted `ImageFormat` enum to select the underlying buffer format.  After all, an `AImage` can be turned into a `HardwareBuffer` which supports a wider range of formats.
