### PR TITLE
ndk-sys: Drop cfg for inexistant `target_arch = "armv7"`

### DIFF
--- a/ndk-sys/src/lib.rs
+++ b/ndk-sys/src/lib.rs
@@ -21,10 +21,7 @@ use jni_sys::*;
 #[cfg(not(any(target_os = "android", feature = "test")))]
 compile_error!("ndk-sys only supports compiling for Android");
 
-#[cfg(all(
-    any(target_os = "android", feature = "test"),
-    any(target_arch = "arm", target_arch = "armv7")
-))]
+#[cfg(all(any(target_os = "android", feature = "test"), target_arch = "arm"))]
 include!("ffi_arm.rs");
 
 #[cfg(all(any(target_os = "android", feature = "test"), target_arch = "aarch64"))]


### PR DESCRIPTION
[Rust nightly since May 6 2024] points out that `armv7` is not a known, valid value for the `target_arch` cfg variable.  This is confirmed by the docs not listing it either: https://doc.rust-lang.org/reference/conditional-compilation.html#target_arch

Hence drop this entirely, and rely purely on `target_arch = "arm"`.

[Rust nightly since May 6 2024]: https://blog.rust-lang.org/2024/05/06/check-cfg.html
